### PR TITLE
⚡ Performance Improvement: Batch Google Tasks Deletions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -95,3 +95,7 @@
 ## 2026-04-10 - ⚡ Bolt: Optimize Todoist sync bounded concurrency
 **Learning:** Sequential processing using array chunking combined with `Promise.all` (e.g. `mappedTasks.slice(i, i+5)`) creates uneven execution patterns where the entire batch is gated by the slowest task in the batch. While better than purely sequential execution, it leaves concurrency windows unutilized.
 **Action:** Replaced manual array chunking with `p-limit(5)` in `src/lib/todoist/sync.ts` to maximize throughput. When doing so, wrapped the limit call in a `try/catch` with `limit.clearQueue()` to preserve fail-fast semantics on error.
+
+## 2024-05-19 - Batch Google Tasks Deletions
+**Learning:** The `pullRemoteTasks` loop previously handled external task deletions sequentially inside a `Promise.all` mapping by issuing individual `db.delete(...)` queries, which caused a textbook N+1 query issue for deletions. While `Promise.all` provides concurrency, triggering too many individual deletes degrades database performance and hits connection limits.
+**Action:** Refactored the `pullRemoteTasks` loop to collect IDs of tasks that need to be deleted into `localTasksToDelete` and `externalIdsToDelete` arrays using a `for...of` loop (while properly skipping the rest of the logic with `continue`). Executed the collected deletions in a single batch outside the loop using Drizzle ORM's `inArray` operator, preventing N+1 queries.

--- a/src/lib/google-tasks/sync.ts
+++ b/src/lib/google-tasks/sync.ts
@@ -319,7 +319,21 @@ async function pullRemoteTasks(params: {
 
     const syncPromises = new Array(remoteTasks.size);
     let syncIndex = 0;
+
+    // ⚡ Bolt Opt: Batch database deletions to prevent N+1 queries.
+    const localTasksToDelete: number[] = [];
+    const externalIdsToDelete: string[] = [];
+
     for (const [externalId, entry] of remoteTasks) {
+        if (entry.task.deleted) {
+            const mappedLocalId = taskExternalToLocal.get(externalId) ?? null;
+            if (mappedLocalId) {
+                localTasksToDelete.push(mappedLocalId);
+                externalIdsToDelete.push(externalId);
+            }
+            continue;
+        }
+
         syncPromises[syncIndex++] = (async () => {
             const { task, tasklistId } = entry;
             const listId = listExternalToLocal.get(tasklistId) ?? null;
@@ -327,23 +341,6 @@ async function pullRemoteTasks(params: {
 
             const mappedLocalId = taskExternalToLocal.get(externalId) ?? null;
             const remoteUpdatedAt = task.updated ? new Date(task.updated) : null;
-
-            if (task.deleted) {
-                if (mappedLocalId) {
-                    await db.delete(tasks).where(and(eq(tasks.id, mappedLocalId), eq(tasks.userId, userId)));
-                    await db
-                        .delete(externalEntityMap)
-                        .where(
-                            and(
-                                eq(externalEntityMap.userId, userId),
-                                eq(externalEntityMap.provider, "google_tasks"),
-                                eq(externalEntityMap.entityType, "task"),
-                                eq(externalEntityMap.externalId, externalId)
-                            )
-                        );
-                }
-                return;
-            }
 
             if (mappedLocalId && localTaskMap.has(mappedLocalId)) {
                 const localTask = localTaskMap.get(mappedLocalId)!;
@@ -428,7 +425,24 @@ async function pullRemoteTasks(params: {
             }
         })();
     }
+
+    syncPromises.length = syncIndex;
     await Promise.all(syncPromises);
+
+    if (localTasksToDelete.length > 0) {
+        await db.delete(tasks).where(and(inArray(tasks.id, localTasksToDelete), eq(tasks.userId, userId)));
+    }
+
+    if (externalIdsToDelete.length > 0) {
+        await db.delete(externalEntityMap).where(
+            and(
+                eq(externalEntityMap.userId, userId),
+                eq(externalEntityMap.provider, "google_tasks"),
+                eq(externalEntityMap.entityType, "task"),
+                inArray(externalEntityMap.externalId, externalIdsToDelete)
+            )
+        );
+    }
 }
 
 async function pushLocalTasks(params: {


### PR DESCRIPTION
💡 **What:** Refactored `pullRemoteTasks` to collect `localTasksToDelete` and `externalIdsToDelete` IDs during iteration, skipping the Promise mapping. The collected arrays are then passed to a single batched `db.delete(...).where(inArray(...))` query outside the loop.
🎯 **Why:** Previously, if 100 tasks were deleted remotely, the sync would issue 200 individual `DELETE` queries (100 for `tasks`, 100 for `externalEntityMap`) concurrently. This created unnecessary database connection overhead and load. By batching them, we reduce this to exactly 2 queries regardless of the number of deletions.
📊 **Measured Improvement:** Replaced O(N) database queries with O(1) database queries for external task deletions. Tested and validated the query logic to ensure arrays properly accumulate IDs and successfully pass to the `inArray` Drizzle operator.

---
*PR created automatically by Jules for task [1246987526280072796](https://jules.google.com/task/1246987526280072796) started by @lassestilvang*