### PR TITLE
🎨 Palette: Add focus-visible styles to TaskItem tooltip triggers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-04-11 - Add focus-visible styles to absolutely positioned buttons
 **Learning:** absolutely positioned inline `<button>` elements (such as the "Add task" `+` icons on calendar grids) often have their native browser focus rings clipped, omitted, or otherwise not styled by default in this application.
 **Action:** When building or modifying such absolutely positioned `<button>` icons, I must append `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring` classes to ensure keyboard navigation remains visibly accessible.
+
+## 2024-04-13 - Add focus-visible styles to custom tabIndex Tooltip triggers
+**Learning:** In components like `TaskItem.tsx`, custom inline tooltip triggers are sometimes built using non-interactive elements like `div` by setting `tabIndex={0}`. While this enables focusability for screen readers, these elements often lack default browser focus indicators, rendering them invisible to keyboard users.
+**Action:** When creating or modifying custom `tabIndex={0}` elements (such as `div` or `span` used for Tooltip triggers), explicitly append `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm` to ensure proper visual feedback during keyboard navigation.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,4 +8,4 @@
 
 ## 2024-04-13 - Add focus-visible styles to custom tabIndex Tooltip triggers
 **Learning:** In components like `TaskItem.tsx`, custom inline tooltip triggers are sometimes built using non-interactive elements like `div` by setting `tabIndex={0}`. While this enables focusability for screen readers, these elements often lack default browser focus indicators, rendering them invisible to keyboard users.
-**Action:** When creating or modifying custom `tabIndex={0}` elements (such as `div` or `span` used for Tooltip triggers), explicitly append `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm` to ensure proper visual feedback during keyboard navigation.
+**Action:** When creating or modifying custom `tabIndex={0}` elements (such as `div` or `span` used for Tooltip triggers), explicitly append `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm` to ensure proper visual feedback during keyboard navigation.

--- a/src/components/tasks/TaskItem.tsx
+++ b/src/components/tasks/TaskItem.tsx
@@ -279,7 +279,7 @@ export const TaskItem = memo(function TaskItem({
                             <Tooltip>
                                 <TooltipTrigger asChild>
                                     <div
-                                        className="cursor-help focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm"
+                                        className="cursor-help focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
                                         aria-label={contextLabels[task.context] || "Context"}
                                         tabIndex={0}
                                     >

--- a/src/components/tasks/TaskItem.tsx
+++ b/src/components/tasks/TaskItem.tsx
@@ -225,7 +225,7 @@ export const TaskItem = memo(function TaskItem({
                             <Tooltip>
                                 <TooltipTrigger asChild>
                                     <div
-                                        className={cn("flex items-center gap-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm", isOverdue ? "text-red-500 font-medium" : "")}
+                                        className={cn("flex items-center gap-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm", isOverdue ? "text-red-500 font-medium" : "")}
                                         aria-label={tooltipContent}
                                         tabIndex={0}
                                     >

--- a/src/components/tasks/TaskItem.tsx
+++ b/src/components/tasks/TaskItem.tsx
@@ -225,7 +225,7 @@ export const TaskItem = memo(function TaskItem({
                             <Tooltip>
                                 <TooltipTrigger asChild>
                                     <div
-                                        className={cn("flex items-center gap-1", isOverdue ? "text-red-500 font-medium" : "")}
+                                        className={cn("flex items-center gap-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm", isOverdue ? "text-red-500 font-medium" : "")}
                                         aria-label={tooltipContent}
                                         tabIndex={0}
                                     >
@@ -265,7 +265,7 @@ export const TaskItem = memo(function TaskItem({
                             <Tooltip>
                                 <TooltipTrigger asChild>
                                     <div
-                                        className="cursor-help"
+                                        className="cursor-help focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm"
                                         aria-label={energyLabels[task.energyLevel]}
                                         tabIndex={0}
                                     >
@@ -279,7 +279,7 @@ export const TaskItem = memo(function TaskItem({
                             <Tooltip>
                                 <TooltipTrigger asChild>
                                     <div
-                                        className="cursor-help"
+                                        className="cursor-help focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm"
                                         aria-label={contextLabels[task.context] || "Context"}
                                         tabIndex={0}
                                     >

--- a/src/components/tasks/TaskItem.tsx
+++ b/src/components/tasks/TaskItem.tsx
@@ -265,7 +265,7 @@ export const TaskItem = memo(function TaskItem({
                             <Tooltip>
                                 <TooltipTrigger asChild>
                                     <div
-                                        className="cursor-help focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm"
+                                        className="cursor-help focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
                                         aria-label={energyLabels[task.energyLevel]}
                                         tabIndex={0}
                                     >


### PR DESCRIPTION
💡 What: Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm` to the `div` elements serving as tooltip triggers in `TaskItem.tsx`.
🎯 Why: Keyboard users previously received no visual indication when tabbing to these interactive elements (due date, energy level, context badges), making the UI confusing and inaccessible.
📸 Before/After: Visual focus rings now appear when navigating to the task badges via keyboard.
♿ Accessibility: Improved keyboard navigation feedback for custom `tabIndex={0}` tooltip triggers.

---
*PR created automatically by Jules for task [40582958631321807](https://jules.google.com/task/40582958631321807) started by @lassestilvang*