### PR TITLE
🎨 Palette: Improve accessibility of Clear all filters button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2024-04-14 - Keyboard accessibility on custom interactive buttons
 **Learning:** Custom interactive elements like absolutely positioned buttons or inline toggle buttons often lose their native focus ring styling due to custom layout rules or overflow clipping, making them invisible to keyboard users navigating via Tab.
 **Action:** Consistently append explicitly defined focus utility classes (such as outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:ring-offset-2) to all custom or absolutely positioned <button> components to guarantee visible focus states across different device contexts.
+## 2024-05-18 - Missing ARIA label and focus styles on clear action button
+**Learning:** Found that secondary "clear" actions on filtering panels (like the "Clear all" button in SearchFiltersPanel) might miss explicit ARIA labels and robust keyboard focus styling (`focus-visible`), reducing accessibility for screen reader and keyboard users.
+**Action:** Always verify that "clear" or "reset" buttons, especially those using secondary or ghost variants, have explicitly descriptive `aria-label` attributes and include standard `focus-visible` ring utility classes.

--- a/src/components/search/SearchFiltersPanel.tsx
+++ b/src/components/search/SearchFiltersPanel.tsx
@@ -1,206 +1,269 @@
-
 import React from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
 } from "@/components/ui/select";
-import { X, SlidersHorizontal, ChevronUp, ChevronDown, FolderOpen, Tag, AlertCircle, CheckCircle, Circle } from "lucide-react";
+import {
+  X,
+  SlidersHorizontal,
+  ChevronUp,
+  ChevronDown,
+  FolderOpen,
+  Tag,
+  AlertCircle,
+  CheckCircle,
+  Circle,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 
 export interface SearchFilters {
-    listId?: number | null;
-    labelId?: number;
-    priority?: "none" | "low" | "medium" | "high";
-    status?: "all" | "completed" | "active";
-    sort?: "relevance" | "created" | "due" | "priority";
-    sortOrder?: "asc" | "desc";
+  listId?: number | null;
+  labelId?: number;
+  priority?: "none" | "low" | "medium" | "high";
+  status?: "all" | "completed" | "active";
+  sort?: "relevance" | "created" | "due" | "priority";
+  sortOrder?: "asc" | "desc";
 }
 
 interface SearchFiltersPanelProps {
-    filters: SearchFilters;
-    showFilters: boolean;
-    onToggleFilters: () => void;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    onUpdateFilter: (key: keyof SearchFilters, value: any) => void;
-    onClearFilters: () => void;
-    allLists: Array<{ id: number; name: string }>;
-    allLabels: Array<{ id: number; name: string }>;
+  filters: SearchFilters;
+  showFilters: boolean;
+  onToggleFilters: () => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onUpdateFilter: (key: keyof SearchFilters, value: any) => void;
+  onClearFilters: () => void;
+  allLists: Array<{ id: number; name: string }>;
+  allLabels: Array<{ id: number; name: string }>;
 }
 
 export function SearchFiltersPanel({
-    filters,
-    showFilters,
-    onToggleFilters,
-    onUpdateFilter,
-    onClearFilters,
-    allLists,
-    allLabels
+  filters,
+  showFilters,
+  onToggleFilters,
+  onUpdateFilter,
+  onClearFilters,
+  allLists,
+  allLabels,
 }: SearchFiltersPanelProps) {
-    const hasActiveFilters =
-        filters.listId !== undefined ||
-        filters.labelId !== undefined ||
-        filters.priority !== undefined ||
-        (filters.status && filters.status !== "all") ||
-        (filters.sort && filters.sort !== "relevance");
+  const hasActiveFilters =
+    filters.listId !== undefined ||
+    filters.labelId !== undefined ||
+    filters.priority !== undefined ||
+    (filters.status && filters.status !== "all") ||
+    (filters.sort && filters.sort !== "relevance");
 
-    // ⚡ Bolt Opt: Replaced O(N) Array.find() inside render with O(1) Map lookups.
-    // This reduces the complexity of re-renders when interacting with filter badges or typing in search.
-    const listMap = React.useMemo(() => {
-        const map = new Map<number, string>();
-        for (let i = 0; i < allLists.length; i++) {
-            map.set(allLists[i].id, allLists[i].name);
-        }
-        return map;
-    }, [allLists]);
+  // ⚡ Bolt Opt: Replaced O(N) Array.find() inside render with O(1) Map lookups.
+  // This reduces the complexity of re-renders when interacting with filter badges or typing in search.
+  const listMap = React.useMemo(() => {
+    const map = new Map<number, string>();
+    for (let i = 0; i < allLists.length; i++) {
+      map.set(allLists[i].id, allLists[i].name);
+    }
+    return map;
+  }, [allLists]);
 
-    const labelMap = React.useMemo(() => {
-        const map = new Map<number, string>();
-        for (let i = 0; i < allLabels.length; i++) {
-            map.set(allLabels[i].id, allLabels[i].name);
-        }
-        return map;
-    }, [allLabels]);
+  const labelMap = React.useMemo(() => {
+    const map = new Map<number, string>();
+    for (let i = 0; i < allLabels.length; i++) {
+      map.set(allLabels[i].id, allLabels[i].name);
+    }
+    return map;
+  }, [allLabels]);
 
-    return (
-        <div className="space-y-4">
-            <div className="flex items-center gap-2 flex-wrap">
-                <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={onToggleFilters}
-                    className={cn(hasActiveFilters && "border-primary text-primary")}
-                >
-                    <SlidersHorizontal className="mr-2 h-3.5 w-3.5" />
-                    Filters
-                    {showFilters ? <ChevronUp className="ml-1 h-3.5 w-3.5" /> : <ChevronDown className="ml-1 h-3.5 w-3.5" />}
-                </Button>
-                {hasActiveFilters && (
-                    <Button variant="ghost" size="sm" onClick={onClearFilters} className="text-muted-foreground">
-                        Clear all
-                    </Button>
-                )}
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2 flex-wrap">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onToggleFilters}
+          className={cn(hasActiveFilters && "border-primary text-primary")}
+        >
+          <SlidersHorizontal className="mr-2 h-3.5 w-3.5" />
+          Filters
+          {showFilters ? (
+            <ChevronUp className="ml-1 h-3.5 w-3.5" />
+          ) : (
+            <ChevronDown className="ml-1 h-3.5 w-3.5" />
+          )}
+        </Button>
+        {hasActiveFilters && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onClearFilters}
+            className="text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            aria-label="Clear all filters"
+          >
+            Clear all
+          </Button>
+        )}
 
-                {filters.listId !== undefined && filters.listId !== null && (
-                    <Badge variant="secondary" className="gap-1">
-                        <FolderOpen className="h-3 w-3" />
-                        {listMap.get(filters.listId) ?? "List"}
-                        <button onClick={() => onUpdateFilter("listId", undefined)} className="ml-1 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-full" aria-label="Remove list filter">
-                            <X className="h-3 w-3" />
-                        </button>
-                    </Badge>
-                )}
-                {filters.labelId && (
-                    <Badge variant="secondary" className="gap-1">
-                        <Tag className="h-3 w-3" />
-                        {labelMap.get(filters.labelId) ?? "Label"}
-                        <button onClick={() => onUpdateFilter("labelId", undefined)} className="ml-1 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-full" aria-label="Remove label filter">
-                            <X className="h-3 w-3" />
-                        </button>
-                    </Badge>
-                )}
-                {filters.priority && (
-                    <Badge variant="secondary" className="gap-1">
-                        <AlertCircle className="h-3 w-3" />
-                        {filters.priority}
-                        <button onClick={() => onUpdateFilter("priority", undefined)} className="ml-1 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-full" aria-label="Remove priority filter">
-                            <X className="h-3 w-3" />
-                        </button>
-                    </Badge>
-                )}
-                {filters.status && filters.status !== "all" && (
-                    <Badge variant="secondary" className="gap-1">
-                        {filters.status === "completed" ? <CheckCircle className="h-3 w-3" /> : <Circle className="h-3 w-3" />}
-                        {filters.status}
-                        <button onClick={() => onUpdateFilter("status", undefined)} className="ml-1 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-full" aria-label="Remove status filter">
-                            <X className="h-3 w-3" />
-                        </button>
-                    </Badge>
-                )}
-            </div>
-
-            {showFilters && (
-                <div className="grid grid-cols-2 md:grid-cols-4 gap-3 p-4 rounded-lg border bg-card">
-                    <FilterSelect
-                        label="List"
-                        value={filters.listId != null ? String(filters.listId) : "all"}
-                        onValueChange={(v) => onUpdateFilter("listId", v === "all" ? undefined : Number(v))}
-                        options={[{ label: "All lists", value: "all" }, ...allLists.map(l => ({ label: l.name, value: String(l.id) }))]}
-                    />
-                    <FilterSelect
-                        label="Label"
-                        value={filters.labelId ? String(filters.labelId) : "all"}
-                        onValueChange={(v) => onUpdateFilter("labelId", v === "all" ? undefined : Number(v))}
-                        options={[{ label: "All labels", value: "all" }, ...allLabels.map(l => ({ label: l.name, value: String(l.id) }))]}
-                    />
-                    <FilterSelect
-                        label="Priority"
-                        value={filters.priority ?? "all"}
-                        onValueChange={(v) => onUpdateFilter("priority", v === "all" ? undefined : v)}
-                        options={[
-                            { label: "Any priority", value: "all" },
-                            { label: "High", value: "high" },
-                            { label: "Medium", value: "medium" },
-                            { label: "Low", value: "low" },
-                            { label: "None", value: "none" }
-                        ]}
-                    />
-                    <FilterSelect
-                        label="Status"
-                        value={filters.status ?? "all"}
-                        onValueChange={(v) => onUpdateFilter("status", v)}
-                        options={[
-                            { label: "All", value: "all" },
-                            { label: "Active", value: "active" },
-                            { label: "Completed", value: "completed" }
-                        ]}
-                    />
-                    <FilterSelect
-                        label="Sort by"
-                        value={filters.sort ?? "relevance"}
-                        onValueChange={(v) => onUpdateFilter("sort", v)}
-                        options={[
-                            { label: "Relevance", value: "relevance" },
-                            { label: "Created date", value: "created" },
-                            { label: "Due date", value: "due" },
-                            { label: "Priority", value: "priority" }
-                        ]}
-                    />
-                    <FilterSelect
-                        label="Order"
-                        value={filters.sortOrder ?? "desc"}
-                        onValueChange={(v) => onUpdateFilter("sortOrder", v)}
-                        options={[
-                            { label: "Newest first", value: "desc" },
-                            { label: "Oldest first", value: "asc" }
-                        ]}
-                    />
-                </div>
+        {filters.listId !== undefined && filters.listId !== null && (
+          <Badge variant="secondary" className="gap-1">
+            <FolderOpen className="h-3 w-3" />
+            {listMap.get(filters.listId) ?? "List"}
+            <button
+              onClick={() => onUpdateFilter("listId", undefined)}
+              className="ml-1 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-full"
+              aria-label="Remove list filter"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </Badge>
+        )}
+        {filters.labelId && (
+          <Badge variant="secondary" className="gap-1">
+            <Tag className="h-3 w-3" />
+            {labelMap.get(filters.labelId) ?? "Label"}
+            <button
+              onClick={() => onUpdateFilter("labelId", undefined)}
+              className="ml-1 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-full"
+              aria-label="Remove label filter"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </Badge>
+        )}
+        {filters.priority && (
+          <Badge variant="secondary" className="gap-1">
+            <AlertCircle className="h-3 w-3" />
+            {filters.priority}
+            <button
+              onClick={() => onUpdateFilter("priority", undefined)}
+              className="ml-1 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-full"
+              aria-label="Remove priority filter"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </Badge>
+        )}
+        {filters.status && filters.status !== "all" && (
+          <Badge variant="secondary" className="gap-1">
+            {filters.status === "completed" ? (
+              <CheckCircle className="h-3 w-3" />
+            ) : (
+              <Circle className="h-3 w-3" />
             )}
+            {filters.status}
+            <button
+              onClick={() => onUpdateFilter("status", undefined)}
+              className="ml-1 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-full"
+              aria-label="Remove status filter"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </Badge>
+        )}
+      </div>
+
+      {showFilters && (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3 p-4 rounded-lg border bg-card">
+          <FilterSelect
+            label="List"
+            value={filters.listId != null ? String(filters.listId) : "all"}
+            onValueChange={(v) =>
+              onUpdateFilter("listId", v === "all" ? undefined : Number(v))
+            }
+            options={[
+              { label: "All lists", value: "all" },
+              ...allLists.map((l) => ({ label: l.name, value: String(l.id) })),
+            ]}
+          />
+          <FilterSelect
+            label="Label"
+            value={filters.labelId ? String(filters.labelId) : "all"}
+            onValueChange={(v) =>
+              onUpdateFilter("labelId", v === "all" ? undefined : Number(v))
+            }
+            options={[
+              { label: "All labels", value: "all" },
+              ...allLabels.map((l) => ({ label: l.name, value: String(l.id) })),
+            ]}
+          />
+          <FilterSelect
+            label="Priority"
+            value={filters.priority ?? "all"}
+            onValueChange={(v) =>
+              onUpdateFilter("priority", v === "all" ? undefined : v)
+            }
+            options={[
+              { label: "Any priority", value: "all" },
+              { label: "High", value: "high" },
+              { label: "Medium", value: "medium" },
+              { label: "Low", value: "low" },
+              { label: "None", value: "none" },
+            ]}
+          />
+          <FilterSelect
+            label="Status"
+            value={filters.status ?? "all"}
+            onValueChange={(v) => onUpdateFilter("status", v)}
+            options={[
+              { label: "All", value: "all" },
+              { label: "Active", value: "active" },
+              { label: "Completed", value: "completed" },
+            ]}
+          />
+          <FilterSelect
+            label="Sort by"
+            value={filters.sort ?? "relevance"}
+            onValueChange={(v) => onUpdateFilter("sort", v)}
+            options={[
+              { label: "Relevance", value: "relevance" },
+              { label: "Created date", value: "created" },
+              { label: "Due date", value: "due" },
+              { label: "Priority", value: "priority" },
+            ]}
+          />
+          <FilterSelect
+            label="Order"
+            value={filters.sortOrder ?? "desc"}
+            onValueChange={(v) => onUpdateFilter("sortOrder", v)}
+            options={[
+              { label: "Newest first", value: "desc" },
+              { label: "Oldest first", value: "asc" },
+            ]}
+          />
         </div>
-    );
+      )}
+    </div>
+  );
 }
 
-function FilterSelect({ label, value, onValueChange, options }: { label: string; value: string; onValueChange: (v: string) => void; options: Array<{ label: string; value: string }> }) {
-    return (
-        <div className="space-y-1.5">
-            <label className="text-xs font-medium text-muted-foreground">{label}</label>
-            <Select value={value} onValueChange={onValueChange}>
-                <SelectTrigger className="h-8">
-                    <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                    {options.map((opt) => (
-                        <SelectItem key={opt.value} value={opt.value}>
-                            {opt.label}
-                        </SelectItem>
-                    ))}
-                </SelectContent>
-            </Select>
-        </div>
-    );
+function FilterSelect({
+  label,
+  value,
+  onValueChange,
+  options,
+}: {
+  label: string;
+  value: string;
+  onValueChange: (v: string) => void;
+  options: Array<{ label: string; value: string }>;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <label className="text-xs font-medium text-muted-foreground">
+        {label}
+      </label>
+      <Select value={value} onValueChange={onValueChange}>
+        <SelectTrigger className="h-8">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((opt) => (
+            <SelectItem key={opt.value} value={opt.value}>
+              {opt.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
 }

--- a/src/components/search/SearchFiltersPanel.tsx
+++ b/src/components/search/SearchFiltersPanel.tsx
@@ -97,7 +97,7 @@ export function SearchFiltersPanel({
             variant="ghost"
             size="sm"
             onClick={onClearFilters}
-            className="text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            className="text-muted-foreground focus-visible:ring-offset-2"
             aria-label="Clear all filters"
           >
             Clear all


### PR DESCRIPTION
🎨 Palette: Add aria-label and focus styles to "Clear all" filters button

💡 **What:** Added an explicit `aria-label` and standard `focus-visible` ring utility classes to the ghost variant "Clear all" button in `SearchFiltersPanel.tsx`.
🎯 **Why:** Keyboard and screen reader users need explicit context and visual feedback when navigating to secondary action buttons like "Clear all" in filter panels, as these styles can sometimes lack adequate native focus indicators or descriptive text context.
♿ **Accessibility:**
- Ensures screen readers announce the button's explicit action ("Clear all filters") rather than just its visible text.
- Provides consistent, high-visibility focus indicators for keyboard-only users.

---
*PR created automatically by Jules for task [5544852836521896713](https://jules.google.com/task/5544852836521896713) started by @lassestilvang*