### PR TITLE
⚡ Bolt: Optimize Set initialization overhead in use-task-list-view

### DIFF
--- a/src/hooks/use-task-list-view.ts
+++ b/src/hooks/use-task-list-view.ts
@@ -40,10 +40,10 @@ export function useTaskListView({
         const yearAnchor = startOfDay(new Date(todayStart.getFullYear(), 0, 1));
 
         if (tasksFromProps && tasksFromProps.length > 0 && !filterType) {
-            // ⚡ Bolt Opt: Replaced new Set(array.map()) with for...of to avoid O(N) intermediate array allocation
             const propIds = new Set<number>();
-            for (const t of tasksFromProps) {
-                propIds.add(t.id);
+            const len = tasksFromProps.length;
+            for (let i = 0; i < len; i++) {
+                propIds.add(tasksFromProps[i].id);
             }
             return allStoreTasks.filter(t => propIds.has(t.id) || t.id < 0);
         }

--- a/src/hooks/use-task-list-view.ts
+++ b/src/hooks/use-task-list-view.ts
@@ -40,7 +40,11 @@ export function useTaskListView({
         const yearAnchor = startOfDay(new Date(todayStart.getFullYear(), 0, 1));
 
         if (tasksFromProps && tasksFromProps.length > 0 && !filterType) {
-            const propIds = new Set(tasksFromProps.map(t => t.id));
+            // ⚡ Bolt Opt: Replaced new Set(array.map()) with for...of to avoid O(N) intermediate array allocation
+            const propIds = new Set<number>();
+            for (const t of tasksFromProps) {
+                propIds.add(t.id);
+            }
             return allStoreTasks.filter(t => propIds.has(t.id) || t.id < 0);
         }
 


### PR DESCRIPTION
Replaced an intermediate .map() allocation when instantiating a Set in the use-task-list-view hook to reduce garbage collection overhead during React renders.

---
*PR created automatically by Jules for task [13669266152991357901](https://jules.google.com/task/13669266152991357901) started by @lassestilvang*