### PR TITLE
🎨 Palette: Add ARIA labels to Select triggers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -152,3 +152,6 @@
 ## 2026-04-20 - [Theme Switcher Accessibility]
 **Learning:** Found that non-semantic elements (like `Card` components) used as interactive toggles for themes lacked ARIA roles, states, labels, and keyboard navigation. This prevented screen reader users from understanding their purpose and keyboard users from interacting with them.
 **Action:** Always provide explicit ARIA attributes (`role="button"`, `aria-label`, `aria-pressed`) and full keyboard accessibility support (`tabIndex={0}`, `onKeyDown` handlers for "Enter" and "Space", and `focus-visible` utility classes) when converting non-semantic elements into interactive controls.
+
+**Learning:** In forms containing multiple identical `Select` components rendered in a list (like mapping a collection of items to another collection), custom `SelectTrigger` elements (e.g., from `shadcn/ui` / Radix UI) often lack explicit `aria-label`s. Screen reader users will only hear "Select list" and won't know *which* item is being mapped.
+**Action:** Always provide an explicit `aria-label` to custom `SelectTrigger` components that dynamically links the dropdown to its contextual label, e.g., `aria-label={\`Map \${itemName} to list\`}`.

--- a/src/components/settings/GoogleTasksMappingForm.tsx
+++ b/src/components/settings/GoogleTasksMappingForm.tsx
@@ -155,7 +155,7 @@ export function GoogleTasksMappingForm() {
                                 });
                             }}
                         >
-                            <SelectTrigger className="w-full md:w-60">
+                            <SelectTrigger className="w-full md:w-60" aria-label={`Map tasklist ${tasklist.title} to list`}>
                                 <SelectValue placeholder="Select list" />
                             </SelectTrigger>
                             <SelectContent>

--- a/src/components/settings/GoogleTasksMappingForm.tsx
+++ b/src/components/settings/GoogleTasksMappingForm.tsx
@@ -155,7 +155,7 @@ export function GoogleTasksMappingForm() {
                                 });
                             }}
                         >
-                            <SelectTrigger className="w-full md:w-60" aria-label={`Map tasklist ${tasklist.title} to list`}>
+                            <SelectTrigger className="w-full md:w-60" aria-labelledby={`label-${tasklist.id}`}>
                                 <SelectValue placeholder="Select list" />
                             </SelectTrigger>
                             <SelectContent>

--- a/src/components/settings/TodoistMappingForm.tsx
+++ b/src/components/settings/TodoistMappingForm.tsx
@@ -315,7 +315,7 @@ export function TodoistMappingForm() {
                                     });
                                 }}
                             >
-                                <SelectTrigger className="w-full md:w-60">
+                                <SelectTrigger className="w-full md:w-60" aria-label={`Map project ${project.name} to list`}>
                                     <SelectValue placeholder="Select list" />
                                 </SelectTrigger>
                                 <SelectContent>
@@ -354,7 +354,7 @@ export function TodoistMappingForm() {
                                     });
                                 }}
                             >
-                                <SelectTrigger className="w-full md:w-60">
+                                <SelectTrigger className="w-full md:w-60" aria-label={`Map label ${label.name} to list`}>
                                     <SelectValue placeholder="Select list" />
                                 </SelectTrigger>
                                 <SelectContent>

--- a/src/components/settings/TodoistMappingForm.tsx
+++ b/src/components/settings/TodoistMappingForm.tsx
@@ -354,7 +354,7 @@ export function TodoistMappingForm() {
                                     });
                                 }}
                             >
-                                <SelectTrigger className="w-full md:w-60" aria-label={`Map label ${label.name} to list`}>
+                                <SelectTrigger className="w-full md:w-60" aria-labelledby={`label-label-${label.id}`}>
                                     <SelectValue placeholder="Select list" />
                                 </SelectTrigger>
                                 <SelectContent>

--- a/src/components/settings/TodoistMappingForm.tsx
+++ b/src/components/settings/TodoistMappingForm.tsx
@@ -315,7 +315,7 @@ export function TodoistMappingForm() {
                                     });
                                 }}
                             >
-                                <SelectTrigger className="w-full md:w-60" aria-label={`Map project ${project.name} to list`}>
+                                <SelectTrigger className="w-full md:w-60" aria-labelledby={`project-label-${project.id}`}>
                                     <SelectValue placeholder="Select list" />
                                 </SelectTrigger>
                                 <SelectContent>


### PR DESCRIPTION
Added descriptive, dynamic `aria-label`s to custom `SelectTrigger` components in settings forms to ensure screen readers provide accurate context for item mappings.

---
*PR created automatically by Jules for task [5243509108484161981](https://jules.google.com/task/5243509108484161981) started by @lassestilvang*