### PR TITLE
🎨 Palette: Add aria-label to Input components

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -155,3 +155,6 @@
 
 **Learning:** In forms containing multiple identical `Select` components rendered in a list (like mapping a collection of items to another collection), custom `SelectTrigger` elements (e.g., from `shadcn/ui` / Radix UI) often lack explicit `aria-label`s. Screen reader users will only hear "Select list" and won't know *which* item is being mapped.
 **Action:** Always provide an explicit `aria-label` to custom `SelectTrigger` components that dynamically links the dropdown to its contextual label, e.g., `aria-label={\`Map \${itemName} to list\`}`.
+## $(date +%Y-%m-%d) - Add aria-label to Input components
+**Learning:** React form inputs (using shadcn's Input component) frequently lack contextual aria-labels when they are used without an associated `<label>` element (like search bars, inline inputs, or file uploads), which negatively impacts screen reader users.
+**Action:** Always add descriptive `aria-label` attributes to `<Input />` components that do not have explicitly linked `<label>` tags.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -155,6 +155,6 @@
 
 **Learning:** In forms containing multiple identical `Select` components rendered in a list (like mapping a collection of items to another collection), custom `SelectTrigger` elements (e.g., from `shadcn/ui` / Radix UI) often lack explicit `aria-label`s. Screen reader users will only hear "Select list" and won't know *which* item is being mapped.
 **Action:** Always provide an explicit `aria-label` to custom `SelectTrigger` components that dynamically links the dropdown to its contextual label, e.g., `aria-label={\`Map \${itemName} to list\`}`.
-## $(date +%Y-%m-%d) - Add aria-label to Input components
+## 2025-03-28 - Add aria-label to Input components
 **Learning:** React form inputs (using shadcn's Input component) frequently lack contextual aria-labels when they are used without an associated `<label>` element (like search bars, inline inputs, or file uploads), which negatively impacts screen reader users.
 **Action:** Always add descriptive `aria-label` attributes to `<Input />` components that do not have explicitly linked `<label>` tags.

--- a/src/components/activity/ActivityLogFilters.tsx
+++ b/src/components/activity/ActivityLogFilters.tsx
@@ -54,6 +54,7 @@ export function ActivityLogFilters({
                     <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                     <Input
                         placeholder="Search activity..."
+                        aria-label="Search activity"
                         className="pl-9 bg-card/50 border-muted"
                         value={searchQuery}
                         onChange={(e) => setSearchQuery(e.target.value)}

--- a/src/components/search/SearchPageClient.tsx
+++ b/src/components/search/SearchPageClient.tsx
@@ -145,6 +145,7 @@ export function SearchPageClient({
                     ref={inputRef}
                     type="text"
                     placeholder="Search tasks, lists, labels..."
+                    aria-label="Search query"
                     value={query}
                     onChange={(e) => dispatch({ type: 'SET_QUERY', payload: e.target.value })}
                     className="h-11 pl-9 pr-10 text-base"

--- a/src/components/settings/CalendarTooltipSettings.tsx
+++ b/src/components/settings/CalendarTooltipSettings.tsx
@@ -124,6 +124,7 @@ export function CalendarTooltipSettings({
                         type="number"
                         min={1}
                         max={20}
+                        aria-label="Dense calendar tooltip threshold"
                         value={threshold ?? ""}
                         onChange={(event) => handleThresholdChange(event.target.value)}
                         disabled={isLoading}

--- a/src/components/settings/DataExportImport.tsx
+++ b/src/components/settings/DataExportImport.tsx
@@ -139,6 +139,7 @@ export function DataExportImport() {
                             id="import-file"
                             type="file"
                             accept=".json"
+                            aria-label="Import data file"
                             onChange={handleImport}
                             disabled={isImporting}
                             className="w-full max-w-[250px]"

--- a/src/components/tasks/CreateTaskInput.tsx
+++ b/src/components/tasks/CreateTaskInput.tsx
@@ -163,6 +163,7 @@ export function CreateTaskInput({ listId, defaultDueDate, userId, defaultLabelId
                         <Input
                             ref={inputRef}
                             value={title}
+                            aria-label="New task title"
                             onChange={(e) => updateTitle(e.target.value)}
                             onFocus={() => dispatchState({ type: "SET_UI_STATE", payload: { isExpanded: true } })}
                             onKeyDown={(e) => {

--- a/src/components/tasks/SubtaskForm.tsx
+++ b/src/components/tasks/SubtaskForm.tsx
@@ -65,6 +65,7 @@ export function SubtaskForm({ subtasks, onAdd, onRemove, onUpdate }: SubtaskForm
                 <Input
                   id={`subtask-title-${subtask.id}`}
                   value={subtask.title}
+                  aria-label="Subtask title"
                   onChange={(e) => onUpdate(subtask.id, "title", e.target.value)}
                   placeholder="Subtask title"
                 />


### PR DESCRIPTION
React form inputs (using shadcn's Input component) frequently lack contextual aria-labels when they are used without an associated `<label>` element (like search bars, inline inputs, or file uploads), which negatively impacts screen reader users.

This PR adds explicit `aria-label` attributes to the following `<Input />` instances to ensure proper screen reader accessibility:
- Search input in `SearchPageClient.tsx`
- Search input in `ActivityLogFilters.tsx`
- New task title input in `CreateTaskInput.tsx`
- Calendar dense threshold input in `CalendarTooltipSettings.tsx`
- JSON import file input in `DataExportImport.tsx`
- Subtask title input in `SubtaskForm.tsx`

Additionally, a journal entry was added to document this practice.

---
*PR created automatically by Jules for task [5704448608644066271](https://jules.google.com/task/5704448608644066271) started by @lassestilvang*