### PR TITLE
🎨 Palette: Add focus-visible styles to inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -165,7 +165,7 @@
 
 ## $(date +%Y-%m-%d) - Added focus-visible styles to inputs
 **Learning:** Found several native `<input>` elements (text inputs for view names, number inputs for time estimates, and range sliders) lacking keyboard focus styles, leading to poor accessibility for keyboard users compared to native UI library components.
-**Action:** Always ensure that custom or raw `<input>` elements include standard focus indicators (e.g., `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`) to maintain consistent keyboard accessibility across the application.
+**Action:** Always ensure that custom or raw `<input>` elements include standard focus indicators (e.g., `outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]`) to maintain consistent keyboard accessibility across the application.
 
 ## $(date +%Y-%m-%d) - Found and removed duplicate prop
 **Learning:** Found an element containing two `aria-label` properties, one hardcoded and one dynamic, which caused an ESLint error and could confuse screen readers due to undefined behavior with conflicting accessibility attributes.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -166,3 +166,7 @@
 ## $(date +%Y-%m-%d) - Added focus-visible styles to inputs
 **Learning:** Found several native `<input>` elements (text inputs for view names, number inputs for time estimates, and range sliders) lacking keyboard focus styles, leading to poor accessibility for keyboard users compared to native UI library components.
 **Action:** Always ensure that custom or raw `<input>` elements include standard focus indicators (e.g., `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`) to maintain consistent keyboard accessibility across the application.
+
+## $(date +%Y-%m-%d) - Found and removed duplicate prop
+**Learning:** Found an element containing two `aria-label` properties, one hardcoded and one dynamic, which caused an ESLint error and could confuse screen readers due to undefined behavior with conflicting accessibility attributes.
+**Action:** When adding or verifying accessibility attributes like `aria-label`, always double check the element to ensure that the attribute isn't already declared earlier in the JSX prop list.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -162,3 +162,7 @@
 ## 2024-04-26 - Add missing aria-labels to scattered button components
 **Learning:** Found several components utilizing standard `<button>` tags (like icon buttons for expanding sections or resetting inputs) without descriptive `aria-label`s, which makes them inaccessible to screen readers.
 **Action:** When creating raw `<button>` elements, specifically those without internal text content or whose text is only an icon or count, explicitly add an `aria-label` to describe the action.
+
+## $(date +%Y-%m-%d) - Added focus-visible styles to inputs
+**Learning:** Found several native `<input>` elements (text inputs for view names, number inputs for time estimates, and range sliders) lacking keyboard focus styles, leading to poor accessibility for keyboard users compared to native UI library components.
+**Action:** Always ensure that custom or raw `<input>` elements include standard focus indicators (e.g., `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`) to maintain consistent keyboard accessibility across the application.

--- a/src/components/tasks/CreateTaskInput.tsx
+++ b/src/components/tasks/CreateTaskInput.tsx
@@ -163,7 +163,6 @@ export function CreateTaskInput({ listId, defaultDueDate, userId, defaultLabelId
                         <Input
                             ref={inputRef}
                             value={title}
-                            aria-label="New task title"
                             onChange={(e) => updateTitle(e.target.value)}
                             onFocus={() => dispatchState({ type: "SET_UI_STATE", payload: { isExpanded: true } })}
                             onKeyDown={(e) => {

--- a/src/components/tasks/TimeEstimateInput.tsx
+++ b/src/components/tasks/TimeEstimateInput.tsx
@@ -116,7 +116,7 @@ export function TimeEstimateInput({ value, onChange, className }: TimeEstimateIn
                                             const mins = Math.max(0, Math.min(55, Number(e.target.value) || 0));
                                             setSliderValue(hours * 60 + mins);
                                         }}
-                                        className="w-full h-10 px-3 rounded-lg border bg-background text-center text-lg font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                        className="w-full h-10 px-3 rounded-lg border bg-background text-center text-lg font-semibold outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
                                     />
                                 </div>
                             </div>

--- a/src/components/tasks/TimeEstimateInput.tsx
+++ b/src/components/tasks/TimeEstimateInput.tsx
@@ -98,7 +98,7 @@ export function TimeEstimateInput({ value, onChange, className }: TimeEstimateIn
                                             const mins = sliderValue % 60;
                                             setSliderValue(hours * 60 + mins);
                                         }}
-                                        className="w-full h-10 px-3 rounded-lg border bg-background text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-primary"
+                                        className="w-full h-10 px-3 rounded-lg border bg-background text-center text-lg font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                                     />
                                 </div>
                                 <span className="text-xl font-bold text-muted-foreground mt-5">:</span>
@@ -116,7 +116,7 @@ export function TimeEstimateInput({ value, onChange, className }: TimeEstimateIn
                                             const mins = Math.max(0, Math.min(55, Number(e.target.value) || 0));
                                             setSliderValue(hours * 60 + mins);
                                         }}
-                                        className="w-full h-10 px-3 rounded-lg border bg-background text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-primary"
+                                        className="w-full h-10 px-3 rounded-lg border bg-background text-center text-lg font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                                     />
                                 </div>
                             </div>
@@ -130,7 +130,7 @@ export function TimeEstimateInput({ value, onChange, className }: TimeEstimateIn
                                     min={5}
                                     max={480}
                                     step={5}
-                                    className="w-full h-2 bg-muted rounded-full appearance-none cursor-pointer accent-primary"
+                                    className="w-full h-2 bg-muted rounded-full appearance-none cursor-pointer accent-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                                 />
                                 <div className="flex justify-between text-xs text-muted-foreground">
                                     <span>5m</span>

--- a/src/components/tasks/TimeEstimateInput.tsx
+++ b/src/components/tasks/TimeEstimateInput.tsx
@@ -98,7 +98,7 @@ export function TimeEstimateInput({ value, onChange, className }: TimeEstimateIn
                                             const mins = sliderValue % 60;
                                             setSliderValue(hours * 60 + mins);
                                         }}
-                                        className="w-full h-10 px-3 rounded-lg border bg-background text-center text-lg font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                        className="w-full h-10 px-3 rounded-lg border bg-background text-center text-lg font-semibold outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
                                     />
                                 </div>
                                 <span className="text-xl font-bold text-muted-foreground mt-5">:</span>

--- a/src/components/tasks/view-options/SaveAsViewSection.tsx
+++ b/src/components/tasks/view-options/SaveAsViewSection.tsx
@@ -22,7 +22,7 @@ export function SaveAsViewSection({
                     value={viewName}
                     onChange={(e) => onViewNameChange(e.target.value)}
                     aria-label="View name"
-                    className="flex-1 px-2 py-1 text-xs border rounded bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    className="flex-1 px-2 py-1 text-xs border rounded bg-background outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
                 />
                 <Button
                     size="sm"

--- a/src/components/tasks/view-options/SaveAsViewSection.tsx
+++ b/src/components/tasks/view-options/SaveAsViewSection.tsx
@@ -22,7 +22,7 @@ export function SaveAsViewSection({
                     value={viewName}
                     onChange={(e) => onViewNameChange(e.target.value)}
                     aria-label="View name"
-                    className="flex-1 px-2 py-1 text-xs border rounded bg-background"
+                    className="flex-1 px-2 py-1 text-xs border rounded bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                 />
                 <Button
                     size="sm"


### PR DESCRIPTION
### 💡 What:
Added explicit `focus-visible` utility classes to raw `<input>` elements in `SaveAsViewSection.tsx` and `TimeEstimateInput.tsx`.

### 🎯 Why:
To ensure keyboard users can clearly see when these inputs receive focus, bringing them in line with the rest of the application's interactive elements that use standard Radix/shadcn focus rings. 

### ♿ Accessibility:
Improved keyboard navigation by making focus states visible for the view name text input, the time estimate number inputs, and the range slider.

---
*PR created automatically by Jules for task [11587049306737899704](https://jules.google.com/task/11587049306737899704) started by @lassestilvang*