### PR TITLE
🎨 Palette: Enhance accessibility of Time Estimate buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -170,3 +170,7 @@
 ## $(date +%Y-%m-%d) - Found and removed duplicate prop
 **Learning:** Found an element containing two `aria-label` properties, one hardcoded and one dynamic, which caused an ESLint error and could confuse screen readers due to undefined behavior with conflicting accessibility attributes.
 **Action:** When adding or verifying accessibility attributes like `aria-label`, always double check the element to ensure that the attribute isn't already declared earlier in the JSX prop list.
+
+## 2024-04-28 - Indicate State on Custom Toggle Buttons
+**Learning:** Custom interactive elements behaving as selectable toggle options (like the time estimate presets) must explicitly use `aria-pressed` to communicate their active state to screen readers. Relying solely on visual changes (like background color swaps) leaves assistive technology users without context.
+**Action:** Always add `aria-pressed={isActive}` when creating a group of custom selectable buttons or chips. Ensure custom buttons also receive explicit `focus-visible` classes since they often lack default browser focus indicators when styled completely from scratch.

--- a/src/components/tasks/TimeEstimateInput.tsx
+++ b/src/components/tasks/TimeEstimateInput.tsx
@@ -52,8 +52,9 @@ export function TimeEstimateInput({ value, onChange, className }: TimeEstimateIn
                         key={preset.value}
                         type="button"
                         onClick={() => onChange(preset.value)}
+                        aria-pressed={value === preset.value}
                         className={cn(
-                            "px-3 py-1.5 text-sm font-medium rounded-full border transition-all duration-200",
+                            "px-3 py-1.5 text-sm font-medium rounded-full border transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                             value === preset.value
                                 ? "bg-primary text-primary-foreground border-primary shadow-sm"
                                 : "bg-background hover:bg-muted border-border text-foreground hover:border-primary/50"
@@ -68,8 +69,9 @@ export function TimeEstimateInput({ value, onChange, className }: TimeEstimateIn
                     <PopoverTrigger asChild>
                         <button
                             type="button"
+                            aria-pressed={value !== null && !isPreset}
                             className={cn(
-                                "px-3 py-1.5 text-sm font-medium rounded-full border transition-all duration-200 flex items-center gap-1",
+                                "px-3 py-1.5 text-sm font-medium rounded-full border transition-all duration-200 flex items-center gap-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                                 value !== null && !isPreset
                                     ? "bg-primary text-primary-foreground border-primary shadow-sm"
                                     : "bg-background hover:bg-muted border-border text-foreground hover:border-primary/50"

--- a/src/components/tasks/TimeEstimateInput.tsx
+++ b/src/components/tasks/TimeEstimateInput.tsx
@@ -71,7 +71,7 @@ export function TimeEstimateInput({ value, onChange, className }: TimeEstimateIn
                             type="button"
                             aria-pressed={value !== null && !isPreset}
                             className={cn(
-                                "px-3 py-1.5 text-sm font-medium rounded-full border transition-all duration-200 flex items-center gap-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                                "px-3 py-1.5 text-sm font-medium rounded-full border transition-all duration-200 flex items-center gap-1 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
                                 value !== null && !isPreset
                                     ? "bg-primary text-primary-foreground border-primary shadow-sm"
                                     : "bg-background hover:bg-muted border-border text-foreground hover:border-primary/50"

--- a/src/components/tasks/TimeEstimateInput.tsx
+++ b/src/components/tasks/TimeEstimateInput.tsx
@@ -54,7 +54,7 @@ export function TimeEstimateInput({ value, onChange, className }: TimeEstimateIn
                         onClick={() => onChange(preset.value)}
                         aria-pressed={value === preset.value}
                         className={cn(
-                            "px-3 py-1.5 text-sm font-medium rounded-full border transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                            "px-3 py-1.5 text-sm font-medium rounded-full border transition-all duration-200 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
                             value === preset.value
                                 ? "bg-primary text-primary-foreground border-primary shadow-sm"
                                 : "bg-background hover:bg-muted border-border text-foreground hover:border-primary/50"


### PR DESCRIPTION
Added `aria-pressed` state and improved `focus-visible` ring styling to the preset quick-select buttons and the custom popover trigger within the `TimeEstimateInput` component. This ensures screen readers announce the currently active toggle state and keyboard users can clearly see which preset is focused.

---
*PR created automatically by Jules for task [6993114983401567886](https://jules.google.com/task/6993114983401567886) started by @lassestilvang*