### PR TITLE
🛡️ Sentinel: [MEDIUM] Add transaction to subtask creation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -188,3 +188,8 @@
 **Vulnerability:** In `src/lib/actions/gamification.ts`, multiple sequential database modifications (`db.update(userStats)`, `db.insert(userAchievements)`, `db.insert(taskLogs)`) were executed without a database transaction. If one of the later operations failed, it would lead to a partial state update (e.g. XP added, but achievement not unlocked or log not created).
 **Learning:** Sequential, dependent database mutations that enforce business logic integrity must be atomic. Leaving them outside a transaction introduces Time-of-Check to Time-of-Use (TOCTOU) and partial data vulnerability risks, which can be exploited or triggered by network errors.
 **Prevention:** Always wrap multi-step database mutations using `await db.transaction(async (tx) => { ... })` and pass the transaction `tx` object to subsequent queries.
+
+## 2024-05-01 - [Atomicity in sequential database mutations]
+**Vulnerability:** Missing database transactions for sequential mutations (e.g., creating an entity followed by logging the action). If the second mutation fails, it leaves the database in an inconsistent state (partial state updates).
+**Learning:** Sequential database operations that logically belong to a single action must be executed atomically. When Drizzle queries are written independently, an error mid-sequence causes orphaned data or incomplete logging.
+**Prevention:** Always wrap dependent, sequential database mutations (like inserts and their corresponding activity logs) inside a `db.transaction(async (tx) => { ... })` block.

--- a/src/app/api/google-tasks-sync/route.ts
+++ b/src/app/api/google-tasks-sync/route.ts
@@ -5,7 +5,6 @@ import { syncGoogleTasksForUser } from "@/lib/google-tasks/sync";
 import { eq } from "drizzle-orm";
 import pLimit from "p-limit";
 import { constantTimeEqual } from "@/lib/auth-bypass";
-import pLimit from "p-limit";
 
 export async function GET() {
     const headersList = await headers();

--- a/src/lib/actions/tasks/subtasks.ts
+++ b/src/lib/actions/tasks/subtasks.ts
@@ -45,24 +45,28 @@ async function createSubtaskImpl(
     throw new NotFoundError("Parent task not found or access denied");
   }
 
-  const result = await db
-    .insert(tasks)
-    .values({
+  const subtask = await db.transaction(async (tx) => {
+    const result = await tx
+      .insert(tasks)
+      .values({
+        userId,
+        title,
+        parentId,
+        listId: null,
+        estimateMinutes: estimateMinutes || null,
+      })
+      .returning();
+
+    const newSubtask = result[0];
+
+    await tx.insert(taskLogs).values({
       userId,
-      title,
-      parentId,
-      listId: null,
-      estimateMinutes: estimateMinutes || null,
-    })
-    .returning();
+      taskId: parentId,
+      action: "subtask_created",
+      details: `Subtask created: ${title}`,
+    });
 
-  const subtask = result[0];
-
-  await db.insert(taskLogs).values({
-    userId,
-    taskId: parentId,
-    action: "subtask_created",
-    details: `Subtask created: ${title}`,
+    return newSubtask;
   });
 
   revalidatePath("/", "layout");


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing database transactions for sequential database mutations (creating a subtask and logging the action). 
🎯 Impact: If the second database mutation (inserting the log) fails, the application is left in an inconsistent state with orphaned data (a subtask without a creation log).
🔧 Fix: Wrapped the sequential dependent `db.insert` queries inside a single `db.transaction()` to enforce atomicity.
✅ Verification: Ran `bun test src/lib/actions/tasks/` and verified that the relevant action tests pass successfully without issues.

---
*PR created automatically by Jules for task [6057482465460824216](https://jules.google.com/task/6057482465460824216) started by @lassestilvang*