### PR TITLE
🎨 Palette: Improve accessibility of interactive subtask row

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -183,5 +183,5 @@
 **Action:** Ensure that all custom selectable buttons include clear `focus-visible` states using standard utility classes (e.g., `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`) to guarantee keyboard accessibility.
 ## 2024-05-14 - Improve accessibility of interactive wrapper
 
-**Learning:** When using a `<div>` or other non-semantic element with `role="button"` to create an interactive row (like a subtask toggle), it's essential to include an `aria-label` to provide context to screen readers, especially if the element's text content isn't fully descriptive of the action. Additionally, if the interactive element toggles a state, using `aria-pressed` accurately reflects the active/completed status.
-**Action:** Always verify that custom interactive container elements (`role="button"`) provide comprehensive aria attributes (`aria-label`, `aria-pressed`, `aria-expanded`, etc.) to communicate purpose and state explicitly.
+**Learning:** When using a div or other non-semantic element with role="button" to create an interactive row, it's essential to include an aria-label and aria-pressed for context. However, this pattern must be avoided if the row contains other interactive elements (like checkboxes), as nested interactivity is invalid and confusing for screen readers.
+**Action:** Always verify that custom interactive container elements provide comprehensive aria attributes, but prioritize using semantic elements or a single interactive target to avoid nested roles and redundant tab stops.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -181,3 +181,7 @@
 ## 2024-05-20 - Missing Focus Indicators on Custom Dialog Selection Buttons
 **Learning:** Custom interactive buttons used for selection in dialogs (e.g., choosing between local and server versions in a sync conflict dialog) often lack visual focus indicators, even if they correctly use `aria-pressed` to indicate their state. This leaves keyboard users without visual feedback when navigating the options.
 **Action:** Ensure that all custom selectable buttons include clear `focus-visible` states using standard utility classes (e.g., `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`) to guarantee keyboard accessibility.
+## 2024-05-14 - Improve accessibility of interactive wrapper
+
+**Learning:** When using a `<div>` or other non-semantic element with `role="button"` to create an interactive row (like a subtask toggle), it's essential to include an `aria-label` to provide context to screen readers, especially if the element's text content isn't fully descriptive of the action. Additionally, if the interactive element toggles a state, using `aria-pressed` accurately reflects the active/completed status.
+**Action:** Always verify that custom interactive container elements (`role="button"`) provide comprehensive aria attributes (`aria-label`, `aria-pressed`, `aria-expanded`, etc.) to communicate purpose and state explicitly.

--- a/src/components/tasks/SubtaskRow.tsx
+++ b/src/components/tasks/SubtaskRow.tsx
@@ -19,6 +19,8 @@ export const SubtaskRow = memo(function SubtaskRow({ subtask, isCompleted, onTog
         <div
             role="button"
             tabIndex={0}
+            aria-label={`Toggle subtask: ${subtask.title}`}
+            aria-pressed={isCompleted || false}
             onKeyDown={(e) => {
                 if (e.key === "Enter" || e.key === " ") {
                     e.preventDefault();


### PR DESCRIPTION
💡 What: Added `aria-label` and `aria-pressed` attributes to the non-semantic interactive `<div role="button">` wrapper in `SubtaskRow.tsx`.
🎯 Why: Without an `aria-label`, screen readers may only announce "button" and lack context on what toggling the row achieves. Without `aria-pressed`, screen reader users aren't informed of whether the custom button is in an active (completed) or inactive (incomplete) state.
♿ Accessibility: Ensures that keyboard and screen-reader users understand the purpose of the subtask toggle row and its current checked state.

---
*PR created automatically by Jules for task [14842072297184074370](https://jules.google.com/task/14842072297184074370) started by @lassestilvang*