### PR TITLE
🛡️ Sentinel: [MEDIUM] Enforce atomic transactions on integration disconnect

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -193,3 +193,8 @@
 **Vulnerability:** Missing database transactions for sequential mutations (e.g., creating an entity followed by logging the action). If the second mutation fails, it leaves the database in an inconsistent state (partial state updates).
 **Learning:** Sequential database operations that logically belong to a single action must be executed atomically. When Drizzle queries are written independently, an error mid-sequence causes orphaned data or incomplete logging.
 **Prevention:** Always wrap dependent, sequential database mutations (like inserts and their corresponding activity logs) inside a `db.transaction(async (tx) => { ... })` block.
+
+## 2024-05-18 - Enforce Atomic Transactions on Integration Disconnect
+**Vulnerability:** Sequential `db.delete` operations in `disconnectGoogleTasks` and `disconnectTodoist` were executed without a database transaction. If one operation failed, it could leave orphaned data, causing data inconsistencies and potential state leakage.
+**Learning:** Performing multiple related database mutations sequentially without a transaction exposes the system to partial state updates. In scenarios involving the cleanup of scoped data (like integrations or settings), atomicity must be guaranteed.
+**Prevention:** Always enforce atomicity by wrapping sequential dependent database mutations (inserts, updates, or deletes) in a database transaction (`await db.transaction(async (tx) => { ... })`).

--- a/src/lib/actions/google-tasks.ts
+++ b/src/lib/actions/google-tasks.ts
@@ -46,41 +46,45 @@ export async function disconnectGoogleTasks() {
     return { success: true };
   }
 
-  await db
-    .delete(externalIntegrations)
-    .where(
-      and(
-        eq(externalIntegrations.userId, user.id),
-        eq(externalIntegrations.provider, "google_tasks"),
-      ),
-    );
+  // 🛡️ Sentinel: Enforce atomicity by wrapping sequential deletes in a database transaction.
+  // This prevents partial state updates and potential data inconsistencies if a subsequent delete fails.
+  await db.transaction(async (tx) => {
+    await tx
+      .delete(externalIntegrations)
+      .where(
+        and(
+          eq(externalIntegrations.userId, user.id),
+          eq(externalIntegrations.provider, "google_tasks"),
+        ),
+      );
 
-  await db
-    .delete(externalEntityMap)
-    .where(
-      and(
-        eq(externalEntityMap.userId, user.id),
-        eq(externalEntityMap.provider, "google_tasks"),
-      ),
-    );
+    await tx
+      .delete(externalEntityMap)
+      .where(
+        and(
+          eq(externalEntityMap.userId, user.id),
+          eq(externalEntityMap.provider, "google_tasks"),
+        ),
+      );
 
-  await db
-    .delete(externalSyncConflicts)
-    .where(
-      and(
-        eq(externalSyncConflicts.userId, user.id),
-        eq(externalSyncConflicts.provider, "google_tasks"),
-      ),
-    );
+    await tx
+      .delete(externalSyncConflicts)
+      .where(
+        and(
+          eq(externalSyncConflicts.userId, user.id),
+          eq(externalSyncConflicts.provider, "google_tasks"),
+        ),
+      );
 
-  await db
-    .delete(externalSyncState)
-    .where(
-      and(
-        eq(externalSyncState.userId, user.id),
-        eq(externalSyncState.provider, "google_tasks"),
-      ),
-    );
+    await tx
+      .delete(externalSyncState)
+      .where(
+        and(
+          eq(externalSyncState.userId, user.id),
+          eq(externalSyncState.provider, "google_tasks"),
+        ),
+      );
+  });
 
   return { success: true };
 }

--- a/src/lib/actions/todoist.ts
+++ b/src/lib/actions/todoist.ts
@@ -298,21 +298,25 @@ export async function disconnectTodoist() {
         return { success: true };
     }
 
-    await db
-        .delete(externalIntegrations)
-        .where(and(eq(externalIntegrations.userId, user.id), eq(externalIntegrations.provider, "todoist")));
+    // 🛡️ Sentinel: Enforce atomicity by wrapping sequential deletes in a database transaction.
+    // This prevents partial state updates and potential data inconsistencies if a subsequent delete fails.
+    await db.transaction(async (tx) => {
+        await tx
+            .delete(externalIntegrations)
+            .where(and(eq(externalIntegrations.userId, user.id), eq(externalIntegrations.provider, "todoist")));
 
-    await db
-        .delete(externalEntityMap)
-        .where(and(eq(externalEntityMap.userId, user.id), eq(externalEntityMap.provider, "todoist")));
+        await tx
+            .delete(externalEntityMap)
+            .where(and(eq(externalEntityMap.userId, user.id), eq(externalEntityMap.provider, "todoist")));
 
-    await db
-        .delete(externalSyncConflicts)
-        .where(and(eq(externalSyncConflicts.userId, user.id), eq(externalSyncConflicts.provider, "todoist")));
+        await tx
+            .delete(externalSyncConflicts)
+            .where(and(eq(externalSyncConflicts.userId, user.id), eq(externalSyncConflicts.provider, "todoist")));
 
-    await db
-        .delete(externalSyncState)
-        .where(and(eq(externalSyncState.userId, user.id), eq(externalSyncState.provider, "todoist")));
+        await tx
+            .delete(externalSyncState)
+            .where(and(eq(externalSyncState.userId, user.id), eq(externalSyncState.provider, "todoist")));
+    });
 
     return { success: true };
 }


### PR DESCRIPTION
Wrapped sequential delete operations in `db.transaction` inside `disconnectGoogleTasks` and `disconnectTodoist` to prevent partial state updates and data inconsistencies. Fixes a potential data integrity issue where orphaned integration mappings could persist.

---
*PR created automatically by Jules for task [1290958795321871228](https://jules.google.com/task/1290958795321871228) started by @lassestilvang*