### PR TITLE
⚡ perf: batch Todoist label sync updates

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -140,3 +140,7 @@
 ## 2026-04-30 - Add p-limit bounded concurrency in Google Tasks sync mapping creation
 **Learning:** Using unbounded `Promise.all` alongside array mapping (`unmappedLists.map(...)`) when making external API calls (e.g., `client.createTasklist()`) risks triggering external rate limiting, especially when dealing with bulk operations like provisioning multiple new task lists.
 **Action:** Replaced unbounded `Promise.all` with bounded `p-limit(5)` concurrency in `src/lib/google-tasks/sync.ts` when creating new unmapped lists. This maximizes throughput while strictly controlling the number of in-flight external API requests, keeping it within safe burst thresholds. A try/catch block was included to preserve fail-fast error behavior by clearing the pending queue on failure.
+
+## 2025-05-03 - Batching External Entity Map Updates
+**Learning:** Sequential database updates inside a loop (N+1 query pattern) create a significant I/O bottleneck, especially in serverless or remote database environments where each round-trip adds substantial latency.
+**Action:** Collect database update queries into an array during loop execution and use `Promise.all()` (or `db.batch()`) to execute them concurrently after the loop. This reduces the total I/O wait time from O(N) to roughly O(1) round-trip.

--- a/src/lib/todoist/sync.ts
+++ b/src/lib/todoist/sync.ts
@@ -262,6 +262,7 @@ export async function syncTodoistForUser(userId: string): Promise<SyncResult> {
 
     const externalEntityMappingsToCreate: (typeof externalEntityMap.$inferInsert)[] =
       [];
+    const externalEntityMappingsToUpdate: any[] = [];
 
     for (const localLabel of localLabels) {
       if (hasScopedMappings && !scopedLocalLabelIds.has(localLabel.id)) {
@@ -282,22 +283,26 @@ export async function syncTodoistForUser(userId: string): Promise<SyncResult> {
 
           const mappingRow = labelMappingByLocalId.get(localLabel.id);
           if (mappingRow) {
-            await db
-              .update(externalEntityMap)
-              .set({ externalId: recreatedLabel.id })
-              .where(eq(externalEntityMap.id, mappingRow.id));
+            externalEntityMappingsToUpdate.push(
+              db
+                .update(externalEntityMap)
+                .set({ externalId: recreatedLabel.id })
+                .where(eq(externalEntityMap.id, mappingRow.id)),
+            );
 
-            await db
-              .update(externalEntityMap)
-              .set({ externalId: recreatedLabel.id })
-              .where(
-                and(
-                  eq(externalEntityMap.userId, userId),
-                  eq(externalEntityMap.provider, "todoist"),
-                  eq(externalEntityMap.entityType, "list_label"),
-                  eq(externalEntityMap.externalId, mappingRow.externalId),
+            externalEntityMappingsToUpdate.push(
+              db
+                .update(externalEntityMap)
+                .set({ externalId: recreatedLabel.id })
+                .where(
+                  and(
+                    eq(externalEntityMap.userId, userId),
+                    eq(externalEntityMap.provider, "todoist"),
+                    eq(externalEntityMap.entityType, "list_label"),
+                    eq(externalEntityMap.externalId, mappingRow.externalId),
+                  ),
                 ),
-              );
+            );
 
             for (const listLabelMapping of mappingState.labels) {
               if (listLabelMapping.labelId === mappingRow.externalId) {
@@ -387,8 +392,18 @@ export async function syncTodoistForUser(userId: string): Promise<SyncResult> {
       );
     }
 
-    if (externalEntityMappingsToCreate.length > 0) {
-      await db.insert(externalEntityMap).values(externalEntityMappingsToCreate);
+    if (
+      externalEntityMappingsToCreate.length > 0 ||
+      externalEntityMappingsToUpdate.length > 0
+    ) {
+      await Promise.all([
+        externalEntityMappingsToCreate.length > 0
+          ? db.insert(externalEntityMap).values(externalEntityMappingsToCreate)
+          : Promise.resolve(),
+        externalEntityMappingsToUpdate.length > 0
+          ? Promise.all(externalEntityMappingsToUpdate)
+          : Promise.resolve(),
+      ]);
     }
 
     const scopedRemoteLabelIds = hasScopedMappings


### PR DESCRIPTION
This PR optimizes the Todoist label synchronization process by batching database updates to the `external_entity_map` table. Previously, these updates were performed sequentially inside a loop, leading to an N+1 query bottleneck. By accumulating the update queries and executing them in a single batch using `Promise.all()`, we significantly reduce the number of database round-trips.

---
*PR created automatically by Jules for task [15670730767683343450](https://jules.google.com/task/15670730767683343450) started by @lassestilvang*