### PR TITLE
🎨 Palette: Add accessibility attributes to Search Filters toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -184,4 +184,7 @@
 ## 2024-05-14 - Improve accessibility of interactive wrapper
 
 **Learning:** When using a div or other non-semantic element with role="button" to create an interactive row, it's essential to include an aria-label and aria-pressed for context. However, this pattern must be avoided if the row contains other interactive elements (like checkboxes), as nested interactivity is invalid and confusing for screen readers.
-**Action:** Always verify that custom interactive container elements provide comprehensive aria attributes, but prioritize using semantic elements or a single interactive target to avoid nested roles and redundant tab stops.
+
+## 2024-05-04 - Add aria-expanded and aria-controls to filter toggle
+**Learning:** For collapsible content panels triggered by a button, screen readers require the button to have `aria-expanded` and `aria-controls` attributes linking to the ID of the content container. Without these, the toggle button’s purpose and the visibility state of the filters remain inaccessible.
+**Action:** Always verify that custom dropdowns, toggles, or filter panels explicitly use `aria-expanded` and `aria-controls` to establish the semantic relationship between the trigger and the content it reveals.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -184,6 +184,7 @@
 ## 2024-05-14 - Improve accessibility of interactive wrapper
 
 **Learning:** When using a div or other non-semantic element with role="button" to create an interactive row, it's essential to include an aria-label and aria-pressed for context. However, this pattern must be avoided if the row contains other interactive elements (like checkboxes), as nested interactivity is invalid and confusing for screen readers.
+**Action:** Always verify that custom interactive container elements provide comprehensive aria attributes, but prioritize using semantic elements or a single interactive target to avoid nested roles and redundant tab stops.
 
 ## 2024-05-04 - Add aria-expanded and aria-controls to filter toggle
 **Learning:** For collapsible content panels triggered by a button, screen readers require the button to have `aria-expanded` and `aria-controls` attributes linking to the ID of the content container. Without these, the toggle button’s purpose and the visibility state of the filters remain inaccessible.

--- a/src/components/search/SearchFiltersPanel.tsx
+++ b/src/components/search/SearchFiltersPanel.tsx
@@ -83,6 +83,8 @@ export function SearchFiltersPanel({
           size="sm"
           onClick={onToggleFilters}
           className={cn(hasActiveFilters && "border-primary text-primary")}
+          aria-expanded={showFilters}
+          aria-controls="search-filters-content"
         >
           <SlidersHorizontal className="mr-2 h-3.5 w-3.5" />
           Filters
@@ -163,7 +165,7 @@ export function SearchFiltersPanel({
       </div>
 
       {showFilters && (
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-3 p-4 rounded-lg border bg-card">
+        <div id="search-filters-content" className="grid grid-cols-2 md:grid-cols-4 gap-3 p-4 rounded-lg border bg-card">
           <FilterSelect
             label="List"
             value={filters.listId != null ? String(filters.listId) : "all"}


### PR DESCRIPTION
Adds aria-expanded and aria-controls to the search filters panel toggle button to improve accessibility for screen readers.

---
*PR created automatically by Jules for task [5989038710446901940](https://jules.google.com/task/5989038710446901940) started by @lassestilvang*