### PR TITLE
🛡️ Sentinel: Enforce Atomic Transactions on External Integration Mapping Updates

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -198,3 +198,8 @@
 **Vulnerability:** Sequential `db.delete` operations in `disconnectGoogleTasks` and `disconnectTodoist` were executed without a database transaction. If one operation failed, it could leave orphaned data, causing data inconsistencies and potential state leakage.
 **Learning:** Performing multiple related database mutations sequentially without a transaction exposes the system to partial state updates. In scenarios involving the cleanup of scoped data (like integrations or settings), atomicity must be guaranteed.
 **Prevention:** Always enforce atomicity by wrapping sequential dependent database mutations (inserts, updates, or deletes) in a database transaction (`await db.transaction(async (tx) => { ... })`).
+
+## 2024-05-04 - [Data Integrity] Missing Database Transactions in Mapping Updates
+**Vulnerability:** In `google-tasks.ts` and `todoist.ts`, the external integration mapping functions (`setGoogleTasksListMappings`, `setTodoistProjectMappings`, and `setTodoistLabelMappings`) were executing sequential `db.delete(externalEntityMap)` and `db.insert(externalEntityMap)` operations outside of a database transaction.
+**Learning:** This is a Time-of-Check to Time-of-Use (TOCTOU) / data integrity risk. If the application process crashes or the `insert` query fails after the `delete` operation succeeds, the user's previously existing external entity mappings are permanently lost, leading to broken synchronizations.
+**Prevention:** Always wrap sequences of related and dependent database mutations (like wiping and replacing configuration or mappings) inside a `db.transaction(async (tx) => { ... })` block to ensure atomic execution.

--- a/src/lib/actions/google-tasks.ts
+++ b/src/lib/actions/google-tasks.ts
@@ -264,27 +264,30 @@ export async function setGoogleTasksListMappings(
     return { success: true };
   }
 
-  await db
-    .delete(externalEntityMap)
-    .where(
-      and(
-        eq(externalEntityMap.userId, user.id),
-        eq(externalEntityMap.provider, "google_tasks"),
-        eq(externalEntityMap.entityType, "list"),
-      ),
-    );
+  // 🛡️ Sentinel: Wrap delete and insert in a transaction to prevent partial updates
+  await db.transaction(async (tx) => {
+    await tx
+      .delete(externalEntityMap)
+      .where(
+        and(
+          eq(externalEntityMap.userId, user.id),
+          eq(externalEntityMap.provider, "google_tasks"),
+          eq(externalEntityMap.entityType, "list"),
+        ),
+      );
 
-  if (mappings.length > 0) {
-    await db.insert(externalEntityMap).values(
-      mappings.map((mapping) => ({
-        userId: user.id,
-        provider: "google_tasks" as const,
-        entityType: "list" as const,
-        localId: mapping.listId,
-        externalId: mapping.tasklistId,
-      })),
-    );
-  }
+    if (mappings.length > 0) {
+      await tx.insert(externalEntityMap).values(
+        mappings.map((mapping) => ({
+          userId: user.id,
+          provider: "google_tasks" as const,
+          entityType: "list" as const,
+          localId: mapping.listId,
+          externalId: mapping.tasklistId,
+        })),
+      );
+    }
+  });
 
   await syncGoogleTasksNow();
 

--- a/src/lib/actions/todoist.ts
+++ b/src/lib/actions/todoist.ts
@@ -491,51 +491,54 @@ export async function setTodoistProjectMappings(mappings: { projectId: string; l
         return { success: true };
     }
 
-    if (mappings.length > 0) {
-        await db.insert(externalEntityMap)
-            .values(
-                mappings.map((mapping) => ({
-                    userId: user.id,
-                    provider: "todoist" as const,
-                    entityType: "list" as const,
-                    localId: mapping.listId,
-                    externalId: mapping.projectId,
-                }))
-            )
-            .onConflictDoUpdate({
-                target: [
-                    externalEntityMap.userId,
-                    externalEntityMap.provider,
-                    externalEntityMap.entityType,
-                    externalEntityMap.externalId,
-                ],
-                set: {
-                    localId: sql`excluded.local_id`,
-                    updatedAt: new Date(),
-                },
-            });
-    }
-
     const scopedWhere = and(
         eq(externalEntityMap.userId, user.id),
         eq(externalEntityMap.provider, "todoist"),
         eq(externalEntityMap.entityType, "list")
     );
 
-    if (mappings.length === 0) {
-        await db
-            .delete(externalEntityMap)
-            .where(scopedWhere);
-    } else {
-        await db
-            .delete(externalEntityMap)
-            .where(
-                and(
-                    scopedWhere,
-                    not(inArray(externalEntityMap.externalId, mappings.map((mapping) => mapping.projectId)))
+    // 🛡️ Sentinel: Wrap delete and insert in a transaction to prevent partial updates
+    await db.transaction(async (tx) => {
+        if (mappings.length > 0) {
+            await tx.insert(externalEntityMap)
+                .values(
+                    mappings.map((mapping) => ({
+                        userId: user.id,
+                        provider: "todoist" as const,
+                        entityType: "list" as const,
+                        localId: mapping.listId,
+                        externalId: mapping.projectId,
+                    }))
                 )
-            );
-    }
+                .onConflictDoUpdate({
+                    target: [
+                        externalEntityMap.userId,
+                        externalEntityMap.provider,
+                        externalEntityMap.entityType,
+                        externalEntityMap.externalId,
+                    ],
+                    set: {
+                        localId: sql`excluded.local_id`,
+                        updatedAt: new Date(),
+                    },
+                });
+        }
+
+        if (mappings.length === 0) {
+            await tx
+                .delete(externalEntityMap)
+                .where(scopedWhere);
+        } else {
+            await tx
+                .delete(externalEntityMap)
+                .where(
+                    and(
+                        scopedWhere,
+                        not(inArray(externalEntityMap.externalId, mappings.map((mapping) => mapping.projectId)))
+                    )
+                );
+        }
+    });
 
     return { success: true };
 }
@@ -584,51 +587,54 @@ export async function setTodoistLabelMappings(mappings: { labelId: string; listI
         return { success: true };
     }
 
-    if (mappings.length > 0) {
-        await db.insert(externalEntityMap)
-            .values(
-                mappings.map((mapping) => ({
-                    userId: user.id,
-                    provider: "todoist" as const,
-                    entityType: "list_label" as const,
-                    localId: mapping.listId,
-                    externalId: mapping.labelId,
-                }))
-            )
-            .onConflictDoUpdate({
-                target: [
-                    externalEntityMap.userId,
-                    externalEntityMap.provider,
-                    externalEntityMap.entityType,
-                    externalEntityMap.externalId,
-                ],
-                set: {
-                    localId: sql`excluded.local_id`,
-                    updatedAt: new Date(),
-                },
-            });
-    }
-
     const scopedWhere = and(
         eq(externalEntityMap.userId, user.id),
         eq(externalEntityMap.provider, "todoist"),
         eq(externalEntityMap.entityType, "list_label")
     );
 
-    if (mappings.length === 0) {
-        await db
-            .delete(externalEntityMap)
-            .where(scopedWhere);
-    } else {
-        await db
-            .delete(externalEntityMap)
-            .where(
-                and(
-                    scopedWhere,
-                    not(inArray(externalEntityMap.externalId, mappings.map((mapping) => mapping.labelId)))
+    // 🛡️ Sentinel: Wrap delete and insert in a transaction to prevent partial updates
+    await db.transaction(async (tx) => {
+        if (mappings.length > 0) {
+            await tx.insert(externalEntityMap)
+                .values(
+                    mappings.map((mapping) => ({
+                        userId: user.id,
+                        provider: "todoist" as const,
+                        entityType: "list_label" as const,
+                        localId: mapping.listId,
+                        externalId: mapping.labelId,
+                    }))
                 )
-            );
-    }
+                .onConflictDoUpdate({
+                    target: [
+                        externalEntityMap.userId,
+                        externalEntityMap.provider,
+                        externalEntityMap.entityType,
+                        externalEntityMap.externalId,
+                    ],
+                    set: {
+                        localId: sql`excluded.local_id`,
+                        updatedAt: new Date(),
+                    },
+                });
+        }
+
+        if (mappings.length === 0) {
+            await tx
+                .delete(externalEntityMap)
+                .where(scopedWhere);
+        } else {
+            await tx
+                .delete(externalEntityMap)
+                .where(
+                    and(
+                        scopedWhere,
+                        not(inArray(externalEntityMap.externalId, mappings.map((mapping) => mapping.labelId)))
+                    )
+                );
+        }
+    });
 
     return { success: true };
 }


### PR DESCRIPTION
🛡️ **Sentinel: [HIGH] Fix Time-of-Check to Time-of-Use (TOCTOU) / Data Integrity vulnerability in mapping updates**

* 🚨 **Severity:** HIGH
* 💡 **Vulnerability:** The external mapping actions (`setGoogleTasksListMappings`, `setTodoistProjectMappings`, and `setTodoistLabelMappings`) performed sequential `db.delete(externalEntityMap)` and `db.insert(externalEntityMap)` operations outside of a transaction context.
* 🎯 **Impact:** If the server crashed or the database encountered an issue right after the `delete` operation but before the `insert` completed, the user's existing sync configuration would be completely wiped out with no recovery path. This leads to broken list synchronizations and silent data integrity loss.
* 🔧 **Fix:** Wrapped the dependent `db.delete` and `db.insert` queries for `externalEntityMap` within `await db.transaction(async (tx) => { ... })` blocks to ensure atomic execution.
* ✅ **Verification:** Passed all existing `todoist.mappings.test.ts` and `google-tasks.security.test.ts` tests, ensuring the transactional logic maintains correctness. Build commands and ESLint successfully pass. Recorded learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [1162984090151064569](https://jules.google.com/task/1162984090151064569) started by @lassestilvang*