### PR TITLE
🎨 Palette: Add explicit aria-label to TaskBoardCard

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -187,7 +187,7 @@
 **Action:** Always verify that custom interactive container elements provide comprehensive aria attributes, but prioritize using semantic elements or a single interactive target to avoid nested roles and redundant tab stops.
 ## 2025-05-19 - Add explicit aria-label to complex interactive roles
 **Learning:** When using a `div` or other non-semantic element with `role="button"` as a container for complex content (like icons, multiple spans, due dates, priority labels), screen readers may produce fragmented or unintelligible readouts if there is no explicit top-level `aria-label`.
-**Action:** Always provide an explicit `aria-label` (e.g., `aria-label={\`Edit task: \${task.title}\`}`) to complex composite interactive elements like custom cards to ensure the action and context are clearly communicated.
+**Action:** Always provide an explicit `aria-label` (e.g., `aria-label={\`Edit task: \${task.title}\${task.isCompleted ? ' (completed)' : ''}\`}`) to complex composite interactive elements like custom cards to ensure the action and all critical context (like status or due dates) are clearly communicated.
 
 ## 2024-05-04 - Add aria-expanded and aria-controls to filter toggle
 **Learning:** For collapsible content panels triggered by a button, screen readers require the button to have `aria-expanded` and `aria-controls` attributes linking to the ID of the content container. Without these, the toggle button’s purpose and the visibility state of the filters remain inaccessible.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -185,3 +185,6 @@
 
 **Learning:** When using a div or other non-semantic element with role="button" to create an interactive row, it's essential to include an aria-label and aria-pressed for context. However, this pattern must be avoided if the row contains other interactive elements (like checkboxes), as nested interactivity is invalid and confusing for screen readers.
 **Action:** Always verify that custom interactive container elements provide comprehensive aria attributes, but prioritize using semantic elements or a single interactive target to avoid nested roles and redundant tab stops.
+## 2025-05-19 - Add explicit aria-label to complex interactive roles
+**Learning:** When using a `div` or other non-semantic element with `role="button"` as a container for complex content (like icons, multiple spans, due dates, priority labels), screen readers may produce fragmented or unintelligible readouts if there is no explicit top-level `aria-label`.
+**Action:** Always provide an explicit `aria-label` (e.g., `aria-label={\`Edit task: \${task.title}\`}`) to complex composite interactive elements like custom cards to ensure the action and context are clearly communicated.

--- a/src/components/tasks/board/TaskBoardCard.tsx
+++ b/src/components/tasks/board/TaskBoardCard.tsx
@@ -50,6 +50,7 @@ export function TaskBoardCard({ task, onEdit }: TaskBoardCardProps) {
       {...listeners}
       {...attributes}
       role="button"
+      aria-label={`Edit task: ${task.title}`}
       tabIndex={0}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {

--- a/src/components/tasks/board/TaskBoardCard.tsx
+++ b/src/components/tasks/board/TaskBoardCard.tsx
@@ -50,7 +50,7 @@ export function TaskBoardCard({ task, onEdit }: TaskBoardCardProps) {
       {...listeners}
       {...attributes}
       role="button"
-      aria-label={`Edit task: ${task.title}`}
+      aria-label={`Edit task: ${task.title}${task.isCompleted ? ' (completed)' : ''}${task.dueDate ? ', due ' + (periodLabel || formatFriendlyDate(dueDateValue!)) : ''}${task.priority && task.priority !== 'none' ? ', ' + task.priority + ' priority' : ''}`}
       tabIndex={0}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {


### PR DESCRIPTION
Added an explicit `aria-label` to the custom interactive card component in `TaskBoardCard.tsx` to provide a clear, unified description for screen reader users, preventing fragmented readouts of its complex internal contents.

---
*PR created automatically by Jules for task [6826909321836823540](https://jules.google.com/task/6826909321836823540) started by @lassestilvang*