### PR TITLE
🎨 Palette: Add aria-labels to template form selects

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -185,3 +185,7 @@
 
 **Learning:** When using a div or other non-semantic element with role="button" to create an interactive row, it's essential to include an aria-label and aria-pressed for context. However, this pattern must be avoided if the row contains other interactive elements (like checkboxes), as nested interactivity is invalid and confusing for screen readers.
 **Action:** Always verify that custom interactive container elements provide comprehensive aria attributes, but prioritize using semantic elements or a single interactive target to avoid nested roles and redundant tab stops.
+
+## 2024-05-18 - Add aria-labels to custom select triggers
+**Learning:** Custom UI components like Radix UI's `SelectTrigger` often need explicit `aria-label`s, especially when they are used within forms where the visual label might not be automatically associated by screen readers due to DOM structure or custom styling.
+**Action:** Always check custom `Select` components, especially the `SelectTrigger`, to ensure they have an `aria-label` or `aria-labelledby` attribute pointing to a valid ID when building accessible forms.

--- a/src/components/tasks/template-form/TemplateTaskProperties.tsx
+++ b/src/components/tasks/template-form/TemplateTaskProperties.tsx
@@ -28,7 +28,7 @@ export function TemplateTaskProperties({ formData, updateField }: TemplateTaskPr
                             updateField("priority", value as TemplateFormData["priority"])
                         }
                     >
-                        <SelectTrigger data-testid="priority-select" aria-label="Select priority">
+<SelectTrigger data-testid="priority-select" aria-label="Priority">
                             <SelectValue placeholder="Select priority" />
                         </SelectTrigger>
                         <SelectContent>

--- a/src/components/tasks/template-form/TemplateTaskProperties.tsx
+++ b/src/components/tasks/template-form/TemplateTaskProperties.tsx
@@ -111,7 +111,7 @@ export function TemplateTaskProperties({ formData, updateField }: TemplateTaskPr
                             updateField("context", value as TemplateFormData["context"])
                         }
                     >
-                        <SelectTrigger data-testid="context-select" aria-label="Select context">
+<SelectTrigger data-testid="context-select" aria-label="Context">
                             <SelectValue placeholder="Select context" />
                         </SelectTrigger>
                         <SelectContent>

--- a/src/components/tasks/template-form/TemplateTaskProperties.tsx
+++ b/src/components/tasks/template-form/TemplateTaskProperties.tsx
@@ -91,7 +91,7 @@ export function TemplateTaskProperties({ formData, updateField }: TemplateTaskPr
                             updateField("energyLevel", value as TemplateFormData["energyLevel"])
                         }
                     >
-                        <SelectTrigger data-testid="energy-select" aria-label="Select energy">
+<SelectTrigger data-testid="energy-select" aria-label="Energy Level">
                             <SelectValue placeholder="Select energy" />
                         </SelectTrigger>
                         <SelectContent>

--- a/src/components/tasks/template-form/TemplateTaskProperties.tsx
+++ b/src/components/tasks/template-form/TemplateTaskProperties.tsx
@@ -28,7 +28,7 @@ export function TemplateTaskProperties({ formData, updateField }: TemplateTaskPr
                             updateField("priority", value as TemplateFormData["priority"])
                         }
                     >
-                        <SelectTrigger data-testid="priority-select">
+                        <SelectTrigger data-testid="priority-select" aria-label="Select priority">
                             <SelectValue placeholder="Select priority" />
                         </SelectTrigger>
                         <SelectContent>
@@ -48,7 +48,7 @@ export function TemplateTaskProperties({ formData, updateField }: TemplateTaskPr
                             updateField("dueDateType", value as TemplateFormData["dueDateType"])
                         }
                     >
-                        <SelectTrigger data-testid="due-date-select">
+                        <SelectTrigger data-testid="due-date-select" aria-label="Select due date">
                             <SelectValue placeholder="Select due date" />
                         </SelectTrigger>
                         <SelectContent>
@@ -91,7 +91,7 @@ export function TemplateTaskProperties({ formData, updateField }: TemplateTaskPr
                             updateField("energyLevel", value as TemplateFormData["energyLevel"])
                         }
                     >
-                        <SelectTrigger data-testid="energy-select">
+                        <SelectTrigger data-testid="energy-select" aria-label="Select energy">
                             <SelectValue placeholder="Select energy" />
                         </SelectTrigger>
                         <SelectContent>
@@ -111,7 +111,7 @@ export function TemplateTaskProperties({ formData, updateField }: TemplateTaskPr
                             updateField("context", value as TemplateFormData["context"])
                         }
                     >
-                        <SelectTrigger data-testid="context-select">
+                        <SelectTrigger data-testid="context-select" aria-label="Select context">
                             <SelectValue placeholder="Select context" />
                         </SelectTrigger>
                         <SelectContent>

--- a/src/components/tasks/template-form/TemplateTaskProperties.tsx
+++ b/src/components/tasks/template-form/TemplateTaskProperties.tsx
@@ -48,7 +48,7 @@ export function TemplateTaskProperties({ formData, updateField }: TemplateTaskPr
                             updateField("dueDateType", value as TemplateFormData["dueDateType"])
                         }
                     >
-                        <SelectTrigger data-testid="due-date-select" aria-label="Select due date">
+<SelectTrigger data-testid="due-date-select" aria-label="Due Date">
                             <SelectValue placeholder="Select due date" />
                         </SelectTrigger>
                         <SelectContent>


### PR DESCRIPTION
Added `aria-label` attributes to the custom Radix UI `<SelectTrigger>` components used for "Priority", "Due Date", "Energy Level", and "Context" selection within `TemplateTaskProperties.tsx`. This improves accessibility by providing explicit, context-rich labels for screen reader users when interacting with these dropdown triggers that are not natively linked to a parent `<label>` element.

---
*PR created automatically by Jules for task [7201083391985530282](https://jules.google.com/task/7201083391985530282) started by @lassestilvang*