### PR TITLE
Implement updateTodoistProjectMapping with IDOR protection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -193,3 +193,7 @@
 **Vulnerability:** Missing database transactions for sequential mutations (e.g., creating an entity followed by logging the action). If the second mutation fails, it leaves the database in an inconsistent state (partial state updates).
 **Learning:** Sequential database operations that logically belong to a single action must be executed atomically. When Drizzle queries are written independently, an error mid-sequence causes orphaned data or incomplete logging.
 **Prevention:** Always wrap dependent, sequential database mutations (like inserts and their corresponding activity logs) inside a `db.transaction(async (tx) => { ... })` block.
+## $(date +%Y-%m-%d) - [IDOR in Todoist Project Mapping]
+**Vulnerability:** Insecure Direct Object Reference (IDOR). A user could potentially map their Todoist project to any local list by providing its ID, without the system verifying that they actually owned the target list.
+**Learning:** Server actions performing database mutations must always validate ownership of all target entities against the authenticated user context, even if the action is intended for internal use or integration.
+**Prevention:** Enforce tenant isolation directly in the database query (e.g., \`.where(and(eq(lists.id, listId), eq(lists.userId, userId)))\`) and remove test-only logic bypasses that skip these checks.

--- a/src/lib/actions/todoist.ts
+++ b/src/lib/actions/todoist.ts
@@ -210,6 +210,50 @@ export async function connectTodoist(token: string) {
     return { success: true };
 }
 
+export async function updateTodoistProjectMapping(
+    listId: number | null,
+    mapping: { projectId: string; projectName: string }
+) {
+    const user = await getCurrentUser();
+    if (!user) {
+        return { success: false, error: "Not authenticated" };
+    }
+
+    if (listId !== null) {
+        const validLists = await db
+            .select({ id: lists.id })
+            .from(lists)
+            .where(and(eq(lists.userId, user.id), eq(lists.id, listId)));
+
+        if (validLists.length === 0) {
+            return { success: false, error: "One or more lists not found or access denied" };
+        }
+    }
+
+    await db.insert(externalEntityMap)
+        .values({
+            userId: user.id,
+            provider: "todoist" as const,
+            entityType: "list" as const,
+            localId: listId,
+            externalId: mapping.projectId,
+        })
+        .onConflictDoUpdate({
+            target: [
+                externalEntityMap.userId,
+                externalEntityMap.provider,
+                externalEntityMap.entityType,
+                externalEntityMap.externalId,
+            ],
+            set: {
+                localId: listId,
+                updatedAt: new Date(),
+            },
+        });
+
+    return { success: true };
+}
+
 export async function getTodoistStatus() {
     const user = await getCurrentUser();
     if (!user) {
@@ -483,10 +527,6 @@ export async function setTodoistProjectMappings(mappings: { projectId: string; l
         }
     }
 
-    if (process.env.NODE_ENV === "test") {
-        return { success: true };
-    }
-
     if (mappings.length > 0) {
         await db.insert(externalEntityMap)
             .values(
@@ -574,10 +614,6 @@ export async function setTodoistLabelMappings(mappings: { labelId: string; listI
         if (invalidIds.length > 0) {
             return { success: false, error: "One or more lists not found or access denied" };
         }
-    }
-
-    if (process.env.NODE_ENV === "test") {
-        return { success: true };
     }
 
     if (mappings.length > 0) {

--- a/src/lib/actions/todoist.ts
+++ b/src/lib/actions/todoist.ts
@@ -212,7 +212,7 @@ export async function connectTodoist(token: string) {
 
 export async function updateTodoistProjectMapping(
     listId: number | null,
-    mapping: { projectId: string; projectName: string }
+    mapping: { projectId: string }
 ) {
     const user = await getCurrentUser();
     if (!user) {

--- a/src/test/integration/security-list-idor.test.ts
+++ b/src/test/integration/security-list-idor.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from "bun:test";
 import { setupTestDb, resetTestDb, createTestUser } from "@/test/setup";
 import { db, lists } from "@/db";
 import { createTask, updateTask } from "@/lib/actions/tasks";
-import { setTodoistProjectMappings, setTodoistLabelMappings } from "@/lib/actions/todoist";
+import { setTodoistProjectMappings, setTodoistLabelMappings, updateTodoistProjectMapping } from "@/lib/actions/todoist";
 import { runInAuthContext } from "@/test/mocks";
 
 type ListRow = typeof lists.$inferSelect;
@@ -113,15 +113,18 @@ describe("Security: List IDOR in Task Operations", () => {
         });
 
         // User B tries to map their Todoist project to User A's list
+        // TODO: Need a valid Todoist task ID for realistic testing,
+        // but we'll try to map to User A's list ID
         await runInAuthContext({ id: userBId, email: "b@example.com" }, async () => {
-            const result = await setTodoistProjectMappings([
-                { projectId: "123", listId: listA.id }
-            ]);
+            const updateResult = await updateTodoistProjectMapping(listA.id, {
+                projectId: "todoist-project-123",
+                projectName: "My Project"
+            });
 
             // Verify the action failed
-            expect(result.success).toBe(false);
-            if (!result.success) {
-                expect(result.error).toContain("One or more lists not found or access denied");
+            expect(updateResult.success).toBe(false);
+            if (!updateResult.success) {
+                expect(updateResult.error).toContain("One or more lists not found or access denied");
             }
         });
     });


### PR DESCRIPTION
This PR implements the updateTodoistProjectMapping server action with proper ownership validation to prevent IDOR vulnerabilities. It also refactors existing Todoist mapping actions to remove test-only early returns, ensuring that database logic and security constraints are actually executed and verified during integration tests. The security-list-idor integration test has been updated to cover the new function.

---
*PR created automatically by Jules for task [2764122036991190691](https://jules.google.com/task/2764122036991190691) started by @lassestilvang*