### PR TITLE
🎨 Palette: Add Accessible Label to Time Estimate Slider

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -199,4 +199,4 @@
 
 ## 2025-05-06 - Add Accessible Label to Time Estimate Slider
 **Learning:** Native `<input type="range">` elements used as custom sliders (like the one in `TimeEstimateInput.tsx`) frequently lack contextual text labels that screen readers can interpret, leading to poor accessibility for visually impaired users.
-**Action:** Always ensure that range sliders, or any custom interactive inputs that do not have a visible `<label>` associated with them via `htmlFor`/`id`, have an explicit `aria-label` attribute added to describe their function (e.g., `aria-label="Adjust time estimate"`).
+**Action:** Always ensure that range sliders, or any custom interactive inputs that do not have a visible `<label>` associated with them via `htmlFor`/`id`, have an explicit `aria-label` attribute added to describe their function (e.g., `aria-label="Adjust time estimate"`) and `aria-valuetext` to provide a human-readable description of the current value.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -196,3 +196,7 @@
 ## 2024-05-04 - Add aria-expanded and aria-controls to filter toggle
 **Learning:** For collapsible content panels triggered by a button, screen readers require the button to have `aria-expanded` and `aria-controls` attributes linking to the ID of the content container. Without these, the toggle button’s purpose and the visibility state of the filters remain inaccessible.
 **Action:** Always verify that custom dropdowns, toggles, or filter panels explicitly use `aria-expanded` and `aria-controls` to establish the semantic relationship between the trigger and the content it reveals.
+
+## 2025-05-06 - Add Accessible Label to Time Estimate Slider
+**Learning:** Native `<input type="range">` elements used as custom sliders (like the one in `TimeEstimateInput.tsx`) frequently lack contextual text labels that screen readers can interpret, leading to poor accessibility for visually impaired users.
+**Action:** Always ensure that range sliders, or any custom interactive inputs that do not have a visible `<label>` associated with them via `htmlFor`/`id`, have an explicit `aria-label` attribute added to describe their function (e.g., `aria-label="Adjust time estimate"`).

--- a/src/components/tasks/TimeEstimateInput.tsx
+++ b/src/components/tasks/TimeEstimateInput.tsx
@@ -133,6 +133,7 @@ export function TimeEstimateInput({ value, onChange, className }: TimeEstimateIn
                                     max={480}
                                     step={5}
                                     aria-label="Adjust time estimate"
+                                    aria-valuetext={formatTime(sliderValue)}
                                     className="w-full h-2 bg-muted rounded-full appearance-none cursor-pointer accent-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                                 />
                                 <div className="flex justify-between text-xs text-muted-foreground">

--- a/src/components/tasks/TimeEstimateInput.tsx
+++ b/src/components/tasks/TimeEstimateInput.tsx
@@ -132,6 +132,7 @@ export function TimeEstimateInput({ value, onChange, className }: TimeEstimateIn
                                     min={5}
                                     max={480}
                                     step={5}
+                                    aria-label="Adjust time estimate"
                                     className="w-full h-2 bg-muted rounded-full appearance-none cursor-pointer accent-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                                 />
                                 <div className="flex justify-between text-xs text-muted-foreground">


### PR DESCRIPTION
💡 What: Added an `aria-label` to the range slider input in the `TimeEstimateInput` component.
🎯 Why: Native range inputs without associated labels lack context for visually impaired users.
♿ Accessibility: Ensures that screen readers announce the purpose of the slider ("Adjust time estimate").

---
*PR created automatically by Jules for task [2480886502914299613](https://jules.google.com/task/2480886502914299613) started by @lassestilvang*