### PR TITLE
🛡️ Sentinel: [HIGH] Fix partial state updates in reminders

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -211,3 +211,8 @@
 **Vulnerability:** Partial data state updates during sequential database operations (e.g., creating a task, assigning labels, logging activity). If an operation after the primary entity creation fails, the database is left in an inconsistent state with orphaned records or missing expected metadata.
 **Learning:** Sequential inserts or updates that depend on a common operation (like a primary insertion) must be treated as a single unit of work. Application-level execution does not guarantee atomicity in the event of failures or errors.
 **Prevention:** Always wrap multiple dependent database mutations within a database transaction (`await db.transaction(async (tx) => { ... })`). This ensures that either all operations succeed completely or all fail gracefully, maintaining data integrity.
+
+## $(date +%Y-%m-%d) - [Data Integrity] Missing Transactions in Reminders Actions
+**Vulnerability:** In `src/lib/actions/reminders.ts`, the `createReminderImpl` and `deleteReminderImpl` functions performed sequential database mutations (inserting/deleting a reminder, then inserting a task log) outside of a database transaction.
+**Learning:** Performing multiple related mutations sequentially without a transaction creates a risk of partial state updates if one operation fails, compromising data integrity (e.g., creating a reminder without logging it, or logging its deletion without actually removing it).
+**Prevention:** Always enforce atomicity by wrapping sequential dependent database mutations, such as CRUD operations on primary entities combined with secondary logging or tracking entries, in a `db.transaction(async (tx) => { ... })` block.

--- a/src/lib/actions/reminders.ts
+++ b/src/lib/actions/reminders.ts
@@ -74,16 +74,18 @@ async function createReminderImpl(
     throw new NotFoundError("Task not found or access denied");
   }
 
-  await db.insert(reminders).values({
-    taskId,
-    remindAt,
-  });
+  await db.transaction(async (tx) => {
+    await tx.insert(reminders).values({
+      taskId,
+      remindAt,
+    });
 
-  await db.insert(taskLogs).values({
-    userId,
-    taskId,
-    action: "reminder_added",
-    details: `Reminder set for ${remindAt.toLocaleString()}`,
+    await tx.insert(taskLogs).values({
+      userId,
+      taskId,
+      action: "reminder_added",
+      details: `Reminder set for ${remindAt.toLocaleString()}`,
+    });
   });
 
   revalidatePath("/");
@@ -130,27 +132,29 @@ async function deleteReminderImpl(userId: string, id: number) {
     throw new NotFoundError("Reminder not found or access denied");
   }
 
-  await db.insert(taskLogs).values({
-    userId,
-    taskId: reminder[0].taskId,
-    action: "reminder_removed",
-    details: `Reminder removed for ${reminder[0].remindAt.toLocaleString()}`,
-  });
+  await db.transaction(async (tx) => {
+    await tx.insert(taskLogs).values({
+      userId,
+      taskId: reminder[0].taskId,
+      action: "reminder_removed",
+      details: `Reminder removed for ${reminder[0].remindAt.toLocaleString()}`,
+    });
 
-  await db
-    .delete(reminders)
-    .where(
-      and(
-        eq(reminders.id, id),
-        inArray(
-          reminders.taskId,
-          db
-            .select({ id: tasks.id })
-            .from(tasks)
-            .where(eq(tasks.userId, userId)),
+    await tx
+      .delete(reminders)
+      .where(
+        and(
+          eq(reminders.id, id),
+          inArray(
+            reminders.taskId,
+            tx
+              .select({ id: tasks.id })
+              .from(tasks)
+              .where(eq(tasks.userId, userId)),
+          ),
         ),
-      ),
-    );
+      );
+  });
   revalidatePath("/");
 }
 

--- a/src/lib/actions/reminders.ts
+++ b/src/lib/actions/reminders.ts
@@ -150,7 +150,7 @@ async function deleteReminderImpl(userId: string, id: number) {
             tx
               .select({ id: tasks.id })
               .from(tasks)
-              .where(eq(tasks.userId, userId)),
+              .where(and(eq(tasks.id, reminder[0].taskId), eq(tasks.userId, userId))),
           ),
         ),
       );


### PR DESCRIPTION
Wrapped sequential database operations inside `createReminderImpl` and `deleteReminderImpl` in `await db.transaction` blocks. This ensures that creating/deleting a reminder and logging the action occur atomically, preventing data inconsistencies in case of partial failures.

---
*PR created automatically by Jules for task [14240357677452166158](https://jules.google.com/task/14240357677452166158) started by @lassestilvang*