### PR TITLE
🎨 Palette: Add DialogDescription to LevelUpModal for accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -228,3 +228,7 @@
 ## 2024-05-19 - Accessible Collapsible Sections
 **Learning:** Collapsible lists and sections (like subtasks or overdue tasks) that rely on `aria-expanded` on toggle buttons often miss the corresponding `aria-controls` attribute, breaking the link for screen reader users between the button and the expandable content.
 **Action:** When inspecting or adding `aria-expanded` toggle functionality, always ensure the target container is assigned an `id` and the toggle button includes an `aria-controls="[id]"` attribute to complete the accessible relationship. Use dynamic IDs (e.g. including `task.id` or `listId`) to avoid collisions when multiple sections are rendered on the same page.
+
+## 2024-05-20 - Missing DialogDescription in Radix UI Modals
+**Learning:** Found instances of custom modals (`LevelUpModal.tsx`) where `DialogContent` did not define a `DialogDescription` but Radix UI expects one for accessibility completeness (as per `aria-describedby` requirements).
+**Action:** Always provide a `DialogDescription` within `DialogContent` modals. If visual text is unneeded, append `className="sr-only"` to it to satisfy accessibility requirements without altering the layout.

--- a/src/components/gamification/LevelUpModal.tsx
+++ b/src/components/gamification/LevelUpModal.tsx
@@ -66,7 +66,7 @@ export function LevelUpModal({ open, onOpenChange, level }: LevelUpModalProps) {
                         Level Up!
                     </DialogTitle>
                     <DialogDescription className="sr-only">
-                        You&apos;ve reached a new level!
+                        You&apos;ve reached level {level}!
                     </DialogDescription>
                 </DialogHeader>
 

--- a/src/components/gamification/LevelUpModal.tsx
+++ b/src/components/gamification/LevelUpModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import {
     Dialog,
     DialogContent,
+    DialogDescription,
     DialogHeader,
     DialogTitle,
 } from "@/components/ui/dialog";
@@ -64,6 +65,9 @@ export function LevelUpModal({ open, onOpenChange, level }: LevelUpModalProps) {
                         <Trophy className="h-8 w-8 text-yellow-500" />
                         Level Up!
                     </DialogTitle>
+                    <DialogDescription className="sr-only">
+                        You&apos;ve reached a new level!
+                    </DialogDescription>
                 </DialogHeader>
 
                 <div className="py-6 space-y-4">


### PR DESCRIPTION
💡 What: Added `<DialogDescription className="sr-only">You've reached a new level!</DialogDescription>` to the `LevelUpModal`.
🎯 Why: Radix UI `DialogContent` expects a description element for screen readers. Missing descriptions lead to fragmented/poor accessibility feedback for assistive tech users.
📸 Before/After: Visual changes are nil (used `sr-only`).
♿ Accessibility: Improved screen reader support for the level up gamification modal.

---
*PR created automatically by Jules for task [3150205309743359629](https://jules.google.com/task/3150205309743359629) started by @lassestilvang*