### PR TITLE
🎨 Palette: Add "Add Task" button to empty states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -232,3 +232,6 @@
 ## 2024-05-20 - Missing DialogDescription in Radix UI Modals
 **Learning:** Found instances of custom modals (`LevelUpModal.tsx`) where `DialogContent` did not define a `DialogDescription` but Radix UI expects one for accessibility completeness (as per `aria-describedby` requirements).
 **Action:** Always provide a `DialogDescription` within `DialogContent` modals. If visual text is unneeded, append `className="sr-only"` to it to satisfy accessibility requirements without altering the layout.
+## 2024-05-17 - TaskListEmptyState Call-to-Action
+**Learning:** Found that empty states with only descriptive text ("Add a task to get started.") introduce friction by forcing users to hunt for the relevant action button elsewhere on the screen.
+**Action:** Always include a clear, centered call-to-action button (like "Add Task") directly within the empty state container when appropriate.

--- a/e2e/label-filtering.spec.ts
+++ b/e2e/label-filtering.spec.ts
@@ -16,7 +16,7 @@ test.describe('Label Filtering', () => {
     const nameInput = page.getByPlaceholder(/label name|name/i);
     await nameInput.fill(labelName);
 
-    const createButton = page.getByRole('button', { name: /create|add|save/i });
+    const createButton = page.getByRole('dialog').getByRole('button', { name: 'Save', exact: true });
     await createButton.click();
 
     await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 10000 });

--- a/e2e/labels.create.spec.ts
+++ b/e2e/labels.create.spec.ts
@@ -29,7 +29,7 @@ test.describe('Label Management: Create', () => {
     const nameInput = page.getByPlaceholder(/label name|name/i);
     await nameInput.fill(labelName);
 
-    const createButton = page.getByRole('button', { name: /create|add|save/i });
+    const createButton = page.getByRole('dialog').getByRole('button', { name: 'Save', exact: true });
     await createButton.click();
 
     await expect(page.getByRole('dialog')).not.toBeVisible();

--- a/e2e/labels.navigate.spec.ts
+++ b/e2e/labels.navigate.spec.ts
@@ -20,7 +20,7 @@ test.describe('Label Management: Navigation', () => {
     const nameInput = page.getByPlaceholder(/label name|name/i);
     await nameInput.fill(labelName);
 
-    const createButton = page.getByRole('button', { name: /create|add|save/i });
+    const createButton = page.getByRole('dialog').getByRole('button', { name: 'Save', exact: true });
     await createButton.click();
 
     await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 10000 });

--- a/src/components/tasks/TaskListWithSettings.tsx
+++ b/src/components/tasks/TaskListWithSettings.tsx
@@ -247,7 +247,7 @@ export function TaskListWithSettings({ tasks, title, listId, labelId, defaultDue
     }, [settings]);
 
     if (!isInitialized) return <TaskListSkeleton variant={settings.layout} compact />;
-    if ((settings.layout === "list" ? listTasks.length === 0 && periodSections.length === 0 : processedTasks.length === 0)) return <TaskListEmptyState filterType={filterType} viewId={viewId} />;
+    if ((settings.layout === "list" ? listTasks.length === 0 && periodSections.length === 0 : processedTasks.length === 0)) return <TaskListEmptyState filterType={filterType} viewId={viewId} onAdd={() => handleTaskDialogOpenChange(true)} />;
 
     return (
         <div className="space-y-4">

--- a/src/components/tasks/list/TaskListEmptyState.tsx
+++ b/src/components/tasks/list/TaskListEmptyState.tsx
@@ -1,10 +1,12 @@
 
 import React from "react";
-import { Inbox, Calendar, CheckCircle, Layers, ClipboardList } from "lucide-react";
+import { Inbox, Calendar, CheckCircle, Layers, ClipboardList, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 interface TaskListEmptyStateProps {
     filterType?: string;
     viewId: string;
+    onAdd?: () => void;
 }
 
 const EMPTY_STATES = {
@@ -40,7 +42,7 @@ const EMPTY_STATES = {
     }
 } as const;
 
-export function TaskListEmptyState({ filterType, viewId }: TaskListEmptyStateProps) {
+export function TaskListEmptyState({ filterType, viewId, onAdd }: TaskListEmptyStateProps) {
     const type = (filterType || viewId) as keyof typeof EMPTY_STATES;
     const config = EMPTY_STATES[type] || EMPTY_STATES.default;
     const Icon = config.icon;
@@ -55,7 +57,13 @@ export function TaskListEmptyState({ filterType, viewId }: TaskListEmptyStatePro
                 <Icon className="h-6 w-6" />
             </div>
             <h2 className="font-semibold text-lg mb-1">{config.title}</h2>
-            <p className="text-sm text-muted-foreground">{config.description}</p>
+            <p className="text-sm text-muted-foreground mb-4">{config.description}</p>
+            {onAdd && (
+                <Button onClick={onAdd} size="sm" variant="outline">
+                    <Plus className="w-4 h-4 mr-2" />
+                    Add Task
+                </Button>
+            )}
         </div>
     );
 }

--- a/src/components/tasks/list/TaskListEmptyState.tsx
+++ b/src/components/tasks/list/TaskListEmptyState.tsx
@@ -58,7 +58,7 @@ export function TaskListEmptyState({ filterType, viewId, onAdd }: TaskListEmptyS
                 <Icon className="h-6 w-6" />
             </div>
             <h2 className="font-semibold text-lg mb-1">{config.title}</h2>
-            <p className="text-sm text-muted-foreground mb-4">{config.description}</p>
+            <p className={cn("text-sm text-muted-foreground", onAdd && "mb-4")}>{config.description}</p>
             {onAdd && (
                 <Button onClick={onAdd} size="sm" variant="outline">
                     <Plus className="w-4 h-4 mr-2" />

--- a/src/components/tasks/list/TaskListEmptyState.tsx
+++ b/src/components/tasks/list/TaskListEmptyState.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { Inbox, Calendar, CheckCircle, Layers, ClipboardList, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 interface TaskListEmptyStateProps {
     filterType?: string;

--- a/src/components/tasks/list/TaskListEmptyState.tsx
+++ b/src/components/tasks/list/TaskListEmptyState.tsx
@@ -61,7 +61,7 @@ export function TaskListEmptyState({ filterType, viewId, onAdd }: TaskListEmptyS
             <p className={cn("text-sm text-muted-foreground", onAdd && "mb-4")}>{config.description}</p>
             {onAdd && (
                 <Button onClick={onAdd} size="sm" variant="outline">
-                    <Plus className="w-4 h-4 mr-2" />
+                    <Plus className="w-4 h-4" />
                     Add Task
                 </Button>
             )}


### PR DESCRIPTION
Added an explicit "Add Task" call-to-action button within the `TaskListEmptyState` component.

Empty states that only contain descriptive text (e.g., "Add a task to get started.") introduce friction by forcing users to hunt for the relevant action button elsewhere on the screen. Including a direct CTA inside the empty state reduces interaction cost and follows good UX practices.

---
*PR created automatically by Jules for task [1920952059411934908](https://jules.google.com/task/1920952059411934908) started by @lassestilvang*