### PR TITLE
⚡ Bolt: Replace O(N) Array.find() with O(1) Map lookup in ai-actions.ts

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -188,3 +188,7 @@ Action: When deleting multiple items from an IndexedDB store, open a single read
 ## 2024-05-16 - Prevent Array Allocation in Search Action
 **Learning:** In critical, highly-invoked paths like search, chained `.map()` calls create intermediate arrays that pressure the V8 garbage collector and slightly decrease latency.
 **Action:** Replace `array.map()` operations with explicitly sized arrays (e.g. `new Array(length)`) and standard `for` loops when deriving values, especially for large datasets.
+
+## 2024-05-18 - Replacing O(N) Array.find() inside loops with O(1) Map lookups
+**Learning:** Found a classic performance anti-pattern in `src/lib/ai-actions.ts` where `Array.find()` was used inside an `Array.map()`, causing an O(N*M) time complexity. Since both arrays could be potentially large in production (e.g. mapping over ai suggestions while searching through overdue tasks), this creates an unnecessary bottleneck.
+**Action:** Always precompute a `Map` keyed by the lookup identifier before the loop starts to change the nested search from O(N) to an O(1) dictionary lookup, thus improving the overall time complexity to O(N + M).

--- a/src/lib/ai-actions.ts
+++ b/src/lib/ai-actions.ts
@@ -160,8 +160,14 @@ export async function rescheduleOverdueTasks(): Promise<RescheduleSuggestion[]> 
 
         const suggestions = JSON.parse(textResponse);
 
+        // ⚡ Bolt Opt: Precompute map to replace O(N*M) Array.find() inside loop with O(1) Map lookup
+        const taskMap = new Map<number, (typeof overdueTasks)[number]>();
+        for (const task of overdueTasks) {
+            taskMap.set(task.id, task);
+        }
+
         return suggestions.map((s: RescheduleSuggestion) => {
-            const task = overdueTasks.find(t => t.id === s.taskId);
+            const task = taskMap.get(s.taskId);
             const precision = task?.dueDatePrecision ?? null;
             const suggested = new Date(s.suggestedDate);
             const normalizedDate = precision && precision !== "day"

--- a/src/lib/ai-actions.ts
+++ b/src/lib/ai-actions.ts
@@ -162,7 +162,8 @@ export async function rescheduleOverdueTasks(): Promise<RescheduleSuggestion[]> 
 
         // ⚡ Bolt Opt: Precompute map to replace O(N*M) Array.find() inside loop with O(1) Map lookup
         const taskMap = new Map<number, (typeof overdueTasks)[number]>();
-        for (const task of overdueTasks) {
+        for (let i = 0; i < overdueTasks.length; i++) {
+            const task = overdueTasks[i];
             taskMap.set(task.id, task);
         }
 


### PR DESCRIPTION
💡 **What**: Replaced the `Array.find()` lookup inside the `suggestions.map` loop in `rescheduleOverdueTasks` (`src/lib/ai-actions.ts`) with a precomputed `Map` dictionary lookup.
🎯 **Why**: The previous implementation caused an O(N * M) time complexity because it executed a linear search over `overdueTasks` for every mapped `suggestion`. Precomputing a map reduces this to O(N + M).
📊 **Impact**: Faster suggestion mapping. Although the arrays might be small typically, this eliminates an algorithmic bottleneck as list sizes scale.
🔬 **Measurement**: Verified with unit tests (`bun test src/lib/smart-scheduler.test.ts` and `src/lib/actions.test.ts`), which continue to pass flawlessly.

---
*PR created automatically by Jules for task [2104696553024367018](https://jules.google.com/task/2104696553024367018) started by @lassestilvang*