### PR TITLE
🎨 Palette: Add dynamic aria-labels to custom picker PopoverTriggers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -264,3 +264,6 @@
 ## 2024-05-17 - TaskListEmptyState Call-to-Action
 **Learning:** Found that empty states with only descriptive text ("Add a task to get started.") introduce friction by forcing users to hunt for the relevant action button elsewhere on the screen.
 **Action:** Always include a clear, centered call-to-action button (like "Add Task") directly within the empty state container when appropriate.
+## 2025-05-18 - Missing ARIA Labels on Popover Picker Triggers
+**Learning:** Found that `<Button>` elements acting as `PopoverTrigger`s for complex menus or pickers (like date range, due date, or priority pickers) often rely on dynamic or implicit internal text instead of a clear accessible name. This causes screen readers to announce fragmented internal text (like just reading the date) rather than the action itself (e.g., "Select date range" or "Set priority").
+**Action:** When creating wrapper inputs containing complex sub-menus or pickers using `PopoverTrigger` or similar, always ensure the expanding action button is given an explicit `aria-label` (e.g., `aria-label="Set due date"`) so screen readers provide the proper context for the interaction.

--- a/src/components/activity/ActivityLogFilters.tsx
+++ b/src/components/activity/ActivityLogFilters.tsx
@@ -1,124 +1,179 @@
-
 import React from "react";
-import { Search, History, CheckCircle2, List, Tag, Calendar as CalendarIcon } from "lucide-react";
+import {
+  Search,
+  History,
+  CheckCircle2,
+  List,
+  Tag,
+  Calendar as CalendarIcon,
+} from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
 } from "@/components/ui/select";
 import {
-    Popover,
-    PopoverContent,
-    PopoverTrigger,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
 } from "@/components/ui/popover";
 import { Calendar } from "@/components/ui/calendar";
 
 interface ActivityLogFiltersProps {
-    searchQuery: string;
-    setSearchQuery: (query: string) => void;
-    typeFilter: string;
-    setTypeFilter: (type: string) => void;
-    dateRange: { from: Date | undefined; to: Date | undefined };
-    setDateRange: (range: { from: Date | undefined; to: Date | undefined }) => void;
-    setDatePreset: (preset: "today" | "yesterday" | "week" | "month" | "all") => void;
-    formatDateRangeLabel: () => string;
+  searchQuery: string;
+  setSearchQuery: (query: string) => void;
+  typeFilter: string;
+  setTypeFilter: (type: string) => void;
+  dateRange: { from: Date | undefined; to: Date | undefined };
+  setDateRange: (range: {
+    from: Date | undefined;
+    to: Date | undefined;
+  }) => void;
+  setDatePreset: (
+    preset: "today" | "yesterday" | "week" | "month" | "all",
+  ) => void;
+  formatDateRangeLabel: () => string;
 }
 
 export function ActivityLogFilters({
-    searchQuery,
-    setSearchQuery,
-    typeFilter,
-    setTypeFilter,
-    dateRange,
-    setDateRange,
-    setDatePreset,
-    formatDateRangeLabel,
+  searchQuery,
+  setSearchQuery,
+  typeFilter,
+  setTypeFilter,
+  dateRange,
+  setDateRange,
+  setDatePreset,
+  formatDateRangeLabel,
 }: ActivityLogFiltersProps) {
-    return (
-        <div className="flex flex-col gap-4 mb-8 px-4 sm:px-0">
-            <div>
-                <h1 className="text-4xl font-bold tracking-tight bg-gradient-to-br from-foreground to-foreground/60 bg-clip-text text-transparent">
-                    Activity Log
-                </h1>
-                <p className="text-muted-foreground mt-1">
-                    A detailed history of everything that&apos;s happened in your planner.
-                </p>
-            </div>
+  return (
+    <div className="flex flex-col gap-4 mb-8 px-4 sm:px-0">
+      <div>
+        <h1 className="text-4xl font-bold tracking-tight bg-gradient-to-br from-foreground to-foreground/60 bg-clip-text text-transparent">
+          Activity Log
+        </h1>
+        <p className="text-muted-foreground mt-1">
+          A detailed history of everything that&apos;s happened in your planner.
+        </p>
+      </div>
 
-            <div className="flex flex-wrap items-center gap-2">
-                <div className="relative w-full sm:w-64">
-                    <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-                    <Input
-                        placeholder="Search activity..."
-                        aria-label="Search activity"
-                        className="pl-9 bg-card/50 border-muted"
-                        value={searchQuery}
-                        onChange={(e) => setSearchQuery(e.target.value)}
-                    />
-                </div>
-
-                <Select value={typeFilter} onValueChange={setTypeFilter}>
-                    <SelectTrigger className="w-[160px] bg-card/50 border-muted" aria-label="Filter activity type">
-                        <SelectValue placeholder="All types" />
-                    </SelectTrigger>
-                    <SelectContent>
-                        <SelectItem value="all">
-                            <span className="flex items-center gap-2">
-                                <History className="h-4 w-4 text-slate-500" />
-                                All Types
-                            </span>
-                        </SelectItem>
-                        <SelectItem value="task">
-                            <span className="flex items-center gap-2">
-                                <CheckCircle2 className="h-4 w-4 text-green-500" />
-                                Tasks
-                            </span>
-                        </SelectItem>
-                        <SelectItem value="list">
-                            <span className="flex items-center gap-2">
-                                <List className="h-4 w-4 text-blue-500" />
-                                Lists
-                            </span>
-                        </SelectItem>
-                        <SelectItem value="label">
-                            <span className="flex items-center gap-2">
-                                <Tag className="h-4 w-4 text-purple-500" />
-                                Labels
-                            </span>
-                        </SelectItem>
-                    </SelectContent>
-                </Select>
-
-                <Popover>
-                    <PopoverTrigger asChild>
-                        <Button variant="outline" className="w-auto min-w-[160px] justify-start bg-card/50 border-muted font-normal">
-                            <CalendarIcon className="h-4 w-4 mr-2 text-muted-foreground" />
-                            {formatDateRangeLabel()}
-                        </Button>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-auto p-0" align="start">
-                        <div className="flex flex-col">
-                            <div className="flex gap-1 p-2 border-b">
-                                <Button size="sm" variant="ghost" className="text-xs h-7" onClick={() => setDatePreset("today")}>Today</Button>
-                                <Button size="sm" variant="ghost" className="text-xs h-7" onClick={() => setDatePreset("yesterday")}>Yesterday</Button>
-                                <Button size="sm" variant="ghost" className="text-xs h-7" onClick={() => setDatePreset("week")}>7 days</Button>
-                                <Button size="sm" variant="ghost" className="text-xs h-7" onClick={() => setDatePreset("month")}>30 days</Button>
-                                <Button size="sm" variant="ghost" className="text-xs h-7" onClick={() => setDatePreset("all")}>All</Button>
-                            </div>
-                            <Calendar
-                                mode="range"
-                                selected={{ from: dateRange.from, to: dateRange.to }}
-                                onSelect={(range) => setDateRange({ from: range?.from, to: range?.to })}
-                                numberOfMonths={1}
-                            />
-                        </div>
-                    </PopoverContent>
-                </Popover>
-            </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="relative w-full sm:w-64">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search activity..."
+            aria-label="Search activity"
+            className="pl-9 bg-card/50 border-muted"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+          />
         </div>
-    );
+
+        <Select value={typeFilter} onValueChange={setTypeFilter}>
+          <SelectTrigger
+            className="w-[160px] bg-card/50 border-muted"
+            aria-label="Filter activity type"
+          >
+            <SelectValue placeholder="All types" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">
+              <span className="flex items-center gap-2">
+                <History className="h-4 w-4 text-slate-500" />
+                All Types
+              </span>
+            </SelectItem>
+            <SelectItem value="task">
+              <span className="flex items-center gap-2">
+                <CheckCircle2 className="h-4 w-4 text-green-500" />
+                Tasks
+              </span>
+            </SelectItem>
+            <SelectItem value="list">
+              <span className="flex items-center gap-2">
+                <List className="h-4 w-4 text-blue-500" />
+                Lists
+              </span>
+            </SelectItem>
+            <SelectItem value="label">
+              <span className="flex items-center gap-2">
+                <Tag className="h-4 w-4 text-purple-500" />
+                Labels
+              </span>
+            </SelectItem>
+          </SelectContent>
+        </Select>
+
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button
+              variant="outline"
+              className="w-auto min-w-[160px] justify-start bg-card/50 border-muted font-normal"
+              aria-label={`Select date range, current range is ${formatDateRangeLabel()}`}
+            >
+              <CalendarIcon className="h-4 w-4 mr-2 text-muted-foreground" />
+              {formatDateRangeLabel()}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-auto p-0" align="start">
+            <div className="flex flex-col">
+              <div className="flex gap-1 p-2 border-b">
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="text-xs h-7"
+                  onClick={() => setDatePreset("today")}
+                >
+                  Today
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="text-xs h-7"
+                  onClick={() => setDatePreset("yesterday")}
+                >
+                  Yesterday
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="text-xs h-7"
+                  onClick={() => setDatePreset("week")}
+                >
+                  7 days
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="text-xs h-7"
+                  onClick={() => setDatePreset("month")}
+                >
+                  30 days
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="text-xs h-7"
+                  onClick={() => setDatePreset("all")}
+                >
+                  All
+                </Button>
+              </div>
+              <Calendar
+                mode="range"
+                selected={{ from: dateRange.from, to: dateRange.to }}
+                onSelect={(range) =>
+                  setDateRange({ from: range?.from, to: range?.to })
+                }
+                numberOfMonths={1}
+              />
+            </div>
+          </PopoverContent>
+        </Popover>
+      </div>
+    </div>
+  );
 }

--- a/src/components/tasks/create-task/TaskMetadataBar.tsx
+++ b/src/components/tasks/create-task/TaskMetadataBar.tsx
@@ -138,6 +138,7 @@ export function TaskMetadataBar({
               variant="ghost"
               size="sm"
               className={cn(icon && "text-primary")}
+              aria-label={`Set icon${icon ? `, current icon is ${icon}` : ""}`}
             >
               {icon ? (
                 <ResolvedIcon icon={icon} className="mr-2 h-4 w-4" />

--- a/src/components/tasks/create-task/TaskMetadataBar.tsx
+++ b/src/components/tasks/create-task/TaskMetadataBar.tsx
@@ -1,8 +1,11 @@
-
 import React from "react";
 import { Calendar, Flag, Smile, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { Calendar as CalendarComponent } from "@/components/ui/calendar";
 import { IconPicker } from "@/components/ui/icon-picker";
 import { ResolvedIcon } from "@/components/ui/resolved-icon";
@@ -12,102 +15,154 @@ import { formatFriendlyDate } from "@/lib/time-utils";
 import { State, Action } from "@/lib/tasks/create-task-reducer";
 
 interface TaskMetadataBarProps {
-    state: State;
-    dispatchState: React.Dispatch<Action>;
-    userId: string;
-    isClient: boolean;
+  state: State;
+  dispatchState: React.Dispatch<Action>;
+  userId: string;
+  isClient: boolean;
 }
 
-export function TaskMetadataBar({ state, dispatchState, userId, isClient }: TaskMetadataBarProps) {
-    const {
-        dueDate, priority, isCalendarOpen, isPriorityOpen, icon
-    } = state;
+export function TaskMetadataBar({
+  state,
+  dispatchState,
+  userId,
+  isClient,
+}: TaskMetadataBarProps) {
+  const { dueDate, priority, isCalendarOpen, isPriorityOpen, icon } = state;
 
-    return (
-        <div className="flex items-center justify-between p-2 border-t bg-muted/20 rounded-b-lg">
-            <div className="flex items-center gap-2">
-                <Popover open={isCalendarOpen} onOpenChange={(open) => dispatchState({ type: "SET_UI_STATE", payload: { isCalendarOpen: open } })}>
-                    <PopoverTrigger asChild>
-                        <Button variant="ghost" size="sm" className={cn(dueDate && "text-primary")}>
-                            <Calendar className="mr-2 h-4 w-4" />
-                            {dueDate ? (isClient ? formatFriendlyDate(dueDate, "MMM d") : format(dueDate, "MMM d")) : "Due Date"}
-                        </Button>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-auto p-0">
-                        <CalendarComponent
-                            mode="single"
-                            selected={dueDate}
-                            onSelect={(date) => {
-                                dispatchState({ type: "SET_DUE_DATE", payload: { date: date || undefined, source: "manual", precision: "day" } });
-                                dispatchState({ type: "SET_UI_STATE", payload: { isCalendarOpen: false } });
-                            }}
-                            initialFocus
-                        />
-                    </PopoverContent>
-                </Popover>
+  return (
+    <div className="flex items-center justify-between p-2 border-t bg-muted/20 rounded-b-lg">
+      <div className="flex items-center gap-2">
+        <Popover
+          open={isCalendarOpen}
+          onOpenChange={(open) =>
+            dispatchState({
+              type: "SET_UI_STATE",
+              payload: { isCalendarOpen: open },
+            })
+          }
+        >
+          <PopoverTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className={cn(dueDate && "text-primary")}
+              aria-label={`Set due date, current date is ${dueDate ? (isClient ? formatFriendlyDate(dueDate, "MMM d") : format(dueDate, "MMM d")) : "Not set"}`}
+            >
+              <Calendar className="mr-2 h-4 w-4" />
+              {dueDate
+                ? isClient
+                  ? formatFriendlyDate(dueDate, "MMM d")
+                  : format(dueDate, "MMM d")
+                : "Due Date"}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-auto p-0">
+            <CalendarComponent
+              mode="single"
+              selected={dueDate}
+              onSelect={(date) => {
+                dispatchState({
+                  type: "SET_DUE_DATE",
+                  payload: {
+                    date: date || undefined,
+                    source: "manual",
+                    precision: "day",
+                  },
+                });
+                dispatchState({
+                  type: "SET_UI_STATE",
+                  payload: { isCalendarOpen: false },
+                });
+              }}
+              initialFocus
+            />
+          </PopoverContent>
+        </Popover>
 
-                <Popover open={isPriorityOpen} onOpenChange={(open) => dispatchState({ type: "SET_UI_STATE", payload: { isPriorityOpen: open } })}>
-                    <PopoverTrigger asChild>
-                        <Button variant="ghost" size="sm" className={cn(priority !== "none" && "text-primary")}>
-                            <Flag className="mr-2 h-4 w-4" />
-                            {priority === "none" ? "Priority" : priority.charAt(0).toUpperCase() + priority.slice(1)}
-                        </Button>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-40 p-2">
-                        <div className="grid gap-1">
-                            {["none", "low", "medium", "high"].map((p) => (
-                                <Button
-                                    key={p}
-                                    variant="ghost"
-                                    size="sm"
-                                    className="justify-start"
-                                    onClick={() => {
-                                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                                        dispatchState({ type: "SET_PRIORITY", payload: p as any });
-                                        dispatchState({ type: "SET_UI_STATE", payload: { isPriorityOpen: false } });
-                                    }}
-                                >
-                                    {p.charAt(0).toUpperCase() + p.slice(1)}
-                                </Button>
-                            ))}
-                        </div>
-                    </PopoverContent>
-                </Popover>
+        <Popover
+          open={isPriorityOpen}
+          onOpenChange={(open) =>
+            dispatchState({
+              type: "SET_UI_STATE",
+              payload: { isPriorityOpen: open },
+            })
+          }
+        >
+          <PopoverTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className={cn(priority !== "none" && "text-primary")}
+              aria-label={`Set priority, current priority is ${priority === "none" ? "None" : priority}`}
+            >
+              <Flag className="mr-2 h-4 w-4" />
+              {priority === "none"
+                ? "Priority"
+                : priority.charAt(0).toUpperCase() + priority.slice(1)}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-40 p-2">
+            <div className="grid gap-1">
+              {["none", "low", "medium", "high"].map((p) => (
+                <Button
+                  key={p}
+                  variant="ghost"
+                  size="sm"
+                  className="justify-start"
+                  onClick={() => {
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    dispatchState({ type: "SET_PRIORITY", payload: p as any });
+                    dispatchState({
+                      type: "SET_UI_STATE",
+                      payload: { isPriorityOpen: false },
+                    });
+                  }}
+                >
+                  {p.charAt(0).toUpperCase() + p.slice(1)}
+                </Button>
+              ))}
             </div>
+          </PopoverContent>
+        </Popover>
+      </div>
 
-            <div className="flex items-center gap-2">
-                <IconPicker
-                    value={icon}
-                    onChange={(i) => dispatchState({ type: "SET_ICON", payload: i || undefined })}
-                    userId={userId}
-                    trigger={
-                        <Button
-                            variant="ghost"
-                            size="sm"
-                            className={cn(icon && "text-primary")}
-                        >
-                            {icon ? (
-                                <ResolvedIcon icon={icon} className="mr-2 h-4 w-4" />
-                            ) : (
-                                <Smile className="mr-2 h-4 w-4" />
-                            )}
-                            Icon
-                        </Button>
-                    }
-                />
-                {icon && (
-                    <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-8 w-8 text-muted-foreground hover:text-foreground"
-                        onClick={() => dispatchState({ type: "SET_ICON", payload: undefined })}
-                        title="Remove icon"
-                        aria-label="Remove icon"
-                    >
-                        <X className="h-4 w-4" />
-                    </Button>
-                )}
-            </div>
-        </div>
-    );
+      <div className="flex items-center gap-2">
+        <IconPicker
+          value={icon}
+          onChange={(i) =>
+            dispatchState({ type: "SET_ICON", payload: i || undefined })
+          }
+          userId={userId}
+          trigger={
+            <Button
+              variant="ghost"
+              size="sm"
+              className={cn(icon && "text-primary")}
+            >
+              {icon ? (
+                <ResolvedIcon icon={icon} className="mr-2 h-4 w-4" />
+              ) : (
+                <Smile className="mr-2 h-4 w-4" />
+              )}
+              Icon
+            </Button>
+          }
+        />
+        {icon && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 text-muted-foreground hover:text-foreground"
+            onClick={() =>
+              dispatchState({ type: "SET_ICON", payload: undefined })
+            }
+            title="Remove icon"
+            aria-label="Remove icon"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
💡 **What:** Added dynamic `aria-label` attributes to `<Button>` elements acting as `PopoverTrigger`s for custom pickers.

🎯 **Why:** To prevent screen readers from announcing fragmented or missing context. By providing an explicit label that contains both the action ("Set due date") and the dynamic current value ("current date is May 14"), we ensure full accessibility without hiding state changes from assistive technology.

♿ **Accessibility:**
- Added `aria-label` to the date range picker in `ActivityLogFilters`
- Added dynamic `aria-label` to the due date picker in `TaskMetadataBar`
- Added dynamic `aria-label` to the priority picker in `TaskMetadataBar`

---
*PR created automatically by Jules for task [3552035247458379517](https://jules.google.com/task/3552035247458379517) started by @lassestilvang*