### PR TITLE
🎨 Palette: Add explicit label to Save As View input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -267,3 +267,7 @@
 ## 2025-05-18 - Missing ARIA Labels on Popover Picker Triggers
 **Learning:** Found that `<Button>` elements acting as `PopoverTrigger`s for complex menus or pickers (like date range, due date, or priority pickers) often rely on dynamic or implicit internal text instead of a clear accessible name. This causes screen readers to announce fragmented internal text (like just reading the date) rather than the action itself (e.g., "Select date range" or "Set priority").
 **Action:** When creating wrapper inputs containing complex sub-menus or pickers using `PopoverTrigger` or similar, always ensure the expanding action button is given an explicit `aria-label` (e.g., `aria-label="Set due date"`) so screen readers provide the proper context for the interaction.
+
+## 2024-05-19 - Ensure semantic `<label>` to `<input>` bindings
+**Learning:** While `aria-label` provides accessible names to inputs, using a non-semantic element (like a `div`) as a visual label misses out on native HTML benefits.
+**Action:** Always prefer an explicit `<label>` element with an `htmlFor` attribute that strictly matches the `<input>` element's `id`. This not only provides screen reader context but natively increases the clickable target area for users.

--- a/src/components/tasks/view-options/SaveAsViewSection.tsx
+++ b/src/components/tasks/view-options/SaveAsViewSection.tsx
@@ -1,38 +1,43 @@
-
 import React from "react";
 import { Button } from "@/components/ui/button";
 
 interface SaveAsViewSectionProps {
-    viewName: string;
-    isSaving: boolean;
-    onViewNameChange: (name: string) => void;
-    onSave: () => void;
+  viewName: string;
+  isSaving: boolean;
+  onViewNameChange: (name: string) => void;
+  onSave: () => void;
 }
 
 export function SaveAsViewSection({
-    viewName, isSaving, onViewNameChange, onSave
+  viewName,
+  isSaving,
+  onViewNameChange,
+  onSave,
 }: SaveAsViewSectionProps) {
-    return (
-        <div className="space-y-3">
-            <div className="text-sm font-medium">Save as new view</div>
-            <div className="flex gap-2">
-                <input
-                    type="text"
-                    placeholder="View name..."
-                    value={viewName}
-                    onChange={(e) => onViewNameChange(e.target.value)}
-                    aria-label="View name"
-                    className="flex-1 px-2 py-1 text-xs border rounded bg-background outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
-                />
-                <Button
-                    size="sm"
-                    className="h-8 px-3 text-xs"
-                    onClick={onSave}
-                    disabled={!viewName.trim() || isSaving}
-                >
-                    {isSaving ? "Saving..." : "Save"}
-                </Button>
-            </div>
-        </div>
-    );
+  return (
+    <div className="space-y-3">
+      <label htmlFor="view-name" className="text-sm font-medium">
+        Save as new view
+      </label>
+      <div className="flex gap-2">
+        <input
+          id="view-name"
+          type="text"
+          placeholder="View name..."
+          value={viewName}
+          onChange={(e) => onViewNameChange(e.target.value)}
+          aria-label="View name"
+          className="flex-1 px-2 py-1 text-xs border rounded bg-background outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+        />
+        <Button
+          size="sm"
+          className="h-8 px-3 text-xs"
+          onClick={onSave}
+          disabled={!viewName.trim() || isSaving}
+        >
+          {isSaving ? "Saving..." : "Save"}
+        </Button>
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
💡 What: Replaced a generic `div` label with a semantic HTML `<label>` element properly linked to the input via `htmlFor` and `id` in the `SaveAsViewSection` component.
🎯 Why: While the input had an `aria-label`, adding an explicit semantic label improves accessibility context and natively expands the clickable target area for users clicking on the text "Save as new view".
♿ Accessibility: Ensures standard semantic label-to-input association which is best practice for screen readers and cursor interactions.

---
*PR created automatically by Jules for task [15694339906883551031](https://jules.google.com/task/15694339906883551031) started by @lassestilvang*