### PR TITLE
🎨 Palette: Add ARIA labels to Switch components for better accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -271,3 +271,7 @@
 ## 2024-05-19 - Ensure semantic `<label>` to `<input>` bindings
 **Learning:** While `aria-label` provides accessible names to inputs, using a non-semantic element (like a `div`) as a visual label misses out on native HTML benefits.
 **Action:** Always prefer an explicit `<label>` element with an `htmlFor` attribute that strictly matches the `<input>` element's `id`. This not only provides screen reader context but natively increases the clickable target area for users.
+
+## 2024-05-24 - Accessibility for Switch components without visible explicit labels
+**Learning:** Found that custom `Switch` components implemented via Radix UI often lack explicitly linked `<label htmlFor="id">` elements when placed adjacent to basic informative `<span>` elements or text strings. This causes screen readers to read the switch state (e.g., "checked") without context of what it toggles.
+**Action:** When using isolated toggle inputs or switches that rely on visual proximity rather than explicit semantic linking, ensure `aria-label` is populated via props and propagated down to the `<SwitchPrimitive.Root>` to maintain screen reader context.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -274,4 +274,4 @@
 
 ## 2024-05-24 - Accessibility for Switch components without visible explicit labels
 **Learning:** Found that custom `Switch` components implemented via Radix UI often lack explicitly linked `<label htmlFor="id">` elements when placed adjacent to basic informative `<span>` elements or text strings. This causes screen readers to read the switch state (e.g., "checked") without context of what it toggles.
-**Action:** When using isolated toggle inputs or switches that rely on visual proximity rather than explicit semantic linking, ensure `aria-label` is populated via props and propagated down to the `<SwitchPrimitive.Root>` to maintain screen reader context.
+**Action:** When using toggle inputs or switches adjacent to informative text or span elements, prefer converting the text to an explicit label element with an htmlFor attribute and assigning a matching id to the Switch. Use aria-label only when no visible label is present to maintain screen reader context.

--- a/src/components/tasks/ViewOptionsPopover.tsx
+++ b/src/components/tasks/ViewOptionsPopover.tsx
@@ -127,7 +127,7 @@ export function ViewOptionsPopover({ viewId, userId, settings: propSettings, onS
 
                     <div className="flex items-center justify-between">
                         <span className="text-sm">Completed tasks</span>
-                        <Switch checked={settings.showCompleted} onCheckedChange={v => updateSetting("showCompleted", v)} />
+                        <Switch checked={settings.showCompleted} onCheckedChange={v => updateSetting("showCompleted", v)} aria-label="Show completed tasks" />
                     </div>
 
                     <Separator />

--- a/src/components/ui/switch.test.tsx
+++ b/src/components/ui/switch.test.tsx
@@ -9,19 +9,19 @@ describe("Switch", () => {
     });
 
     it("should render correctly", () => {
-        render(<Switch />);
+        render(<Switch aria-label="Test switch" />);
         const switchEl = screen.getByRole("switch");
         expect(switchEl).toBeInTheDocument();
     });
 
     it("should be unchecked by default", () => {
-        render(<Switch />);
+        render(<Switch aria-label="Test switch" />);
         const switchEl = screen.getByRole("switch");
         expect(switchEl).toHaveAttribute("data-state", "unchecked");
     });
 
     it("should be checked when checked prop is true", () => {
-        render(<Switch checked />);
+        render(<Switch checked aria-label="Test switch" />);
         const switchEl = screen.getByRole("switch");
         expect(switchEl).toHaveAttribute("data-state", "checked");
     });
@@ -31,20 +31,20 @@ describe("Switch", () => {
         const handleChange = (value: boolean) => {
             checked = value;
         };
-        render(<Switch onCheckedChange={handleChange} />);
+        render(<Switch onCheckedChange={handleChange} aria-label="Test switch" />);
         const switchEl = screen.getByRole("switch");
         fireEvent.click(switchEl);
         expect(checked).toBe(true);
     });
 
     it("should be disabled when disabled prop is passed", () => {
-        render(<Switch disabled />);
+        render(<Switch disabled aria-label="Test switch" />);
         const switchEl = screen.getByRole("switch");
         expect(switchEl).toBeDisabled();
     });
 
     it("should apply custom className", () => {
-        render(<Switch className="custom-class" />);
+        render(<Switch className="custom-class" aria-label="Test switch" />);
         const switchEl = screen.getByRole("switch");
         expect(switchEl.className).toContain("custom-class");
     });


### PR DESCRIPTION
💡 **What:** Added an `aria-label` attribute ("Show completed tasks") to the `Switch` component in `ViewOptionsPopover.tsx`. Also updated `switch.test.tsx` to include `aria-label` in tests.
🎯 **Why:** The switch toggle lacked a descriptive label linked to it, causing screen readers to announce "checked" or "unchecked" without proper context of the setting (showing completed tasks).
♿ **Accessibility:** This directly addresses an accessibility violation for screen reader users by providing explicit context for the Switch toggle input.

---
*PR created automatically by Jules for task [5133534356920684242](https://jules.google.com/task/5133534356920684242) started by @lassestilvang*