### PR TITLE
⚡ Bolt: Prevent intermediate array allocations in Todoist sync

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -198,3 +198,6 @@ Action: When deleting multiple items from an IndexedDB store, open a single read
 ## 2025-05-10 - ⚡ Bolt: Prevent Unnecessary Array Allocations in useMemo
 **Learning:** Returning dynamically mapped arrays like `items.map(i => i.id)` directly in a React prop (like `items` for `SortableContext`) allocates a new array on *every render*, defeating memoization of the underlying `items` array and causing deep unneeded re-renders in drag-and-drop contexts.
 **Action:** Always pre-allocate/precompute arrays of derived primitives (like `itemIds`) in the same single-pass loop or `useMemo` block where the parent collection is processed. Then pass the stable memoized primitive array (e.g., `items={itemIds}`) to prevent unnecessary O(N) array allocation overhead during react render cycles.
+## 2026-05-19 - ⚡ Bolt: Prevent intermediate array allocation during Map initialization
+**Learning:** Using the pattern `new Map(array.map(item => [key, val]))` creates an intermediate array of tuples solely for the purpose of initializing the Map. In hot paths like sync functions, this unnecessary memory allocation creates garbage collection overhead.
+**Action:** Always instantiate an empty Map (`new Map()`) and populate it directly using a single-pass `for...of` loop (`map.set(key, val)`) to avoid intermediate array allocations.

--- a/src/lib/actions/todoist.ts
+++ b/src/lib/actions/todoist.ts
@@ -1114,15 +1114,23 @@ export async function resolveTodoistConflict(
       normalizedRemoteTask as never,
       mappingState,
     );
-    const labelIdMap = new Map(
-      labelMappings.map((mapping) => [mapping.externalId, mapping.localId]),
-    );
+    // ⚡ Bolt Opt: Avoid allocating an intermediate array for map initialization
+    const labelIdMap = new Map<string, number | null>();
+    for (const mapping of labelMappings) {
+      labelIdMap.set(mapping.externalId, mapping.localId);
+    }
     const resolvedParentId = remoteTask.parentId
       ? (externalTaskToLocal.get(remoteTask.parentId) ?? null)
       : null;
-    const labelIds = resolvedExternalLabelIds
-      .map((labelId) => labelIdMap.get(labelId))
-      .filter((id): id is number => Boolean(id));
+    // ⚡ Bolt Opt: Replaced chained .map().filter() with a single pass for...of loop
+    // to avoid unnecessary intermediate array allocations
+    const labelIds: number[] = [];
+    for (const labelId of resolvedExternalLabelIds) {
+      const id = labelIdMap.get(labelId);
+      if (id !== undefined && id !== null) {
+        labelIds.push(id);
+      }
+    }
 
     await updateTask(conflict.localId, user.id, {
       title: localUpdates.title,


### PR DESCRIPTION
💡 What: Replaced `new Map(array.map(...))` and chained `.map().filter()` with direct `for...of` loops in `src/lib/actions/todoist.ts`.
🎯 Why: To eliminate unnecessary intermediate array allocations that cause memory pressure and garbage collection overhead during large syncing operations.
📊 Impact: Reduces memory allocations and slightly improves performance during remote task sync and conflict resolution by avoiding intermediate O(N) array creation.
🔬 Measurement: Verify changes manually by syncing Todoist tasks or running `bun test src/test/integration/todoist-sync.test.ts`.

---
*PR created automatically by Jules for task [15830850993330460171](https://jules.google.com/task/15830850993330460171) started by @lassestilvang*