### PR TITLE
⚡ Bolt: Prevent intermediate array allocation in task mutations

### DIFF
--- a/src/lib/actions/tasks/mutations.ts
+++ b/src/lib/actions/tasks/mutations.ts
@@ -353,7 +353,11 @@ async function updateTaskImpl(
     const newLabelIds = [...labelIds].sort();
 
     if (currentLabelIds.length !== newLabelIds.length || !currentLabelIds.every((val, index) => val === newLabelIds[index])) {
-      const currentLabelNamesMap = new Map(currentTask.labels.map((l) => [l.id, l.name || "Unknown"]));
+      // ⚡ Bolt Opt: Replaced new Map(array.map()) with for...of to avoid O(N) intermediate array allocation
+      const currentLabelNamesMap = new Map<number, string>();
+      for (const l of currentTask.labels) {
+        currentLabelNamesMap.set(l.id, l.name || "Unknown");
+      }
 
       const labelsToFetch = newLabelIds.filter(id => !currentLabelNamesMap.has(id));
 

--- a/src/lib/actions/tasks/mutations.ts
+++ b/src/lib/actions/tasks/mutations.ts
@@ -356,6 +356,8 @@ async function updateTaskImpl(
       // ⚡ Bolt Opt: Replaced new Map(array.map()) with for...of to avoid O(N) intermediate array allocation
       const currentLabelNamesMap = new Map<number, string>();
       for (const l of currentTask.labels) {
+      const currentLabelNamesMap = new Map<number, string>();
+      for (const l of currentTask.labels) {
         if (l.id !== null) {
           currentLabelNamesMap.set(l.id, l.name || "Unknown");
         }

--- a/src/lib/actions/tasks/mutations.ts
+++ b/src/lib/actions/tasks/mutations.ts
@@ -356,7 +356,9 @@ async function updateTaskImpl(
       // ⚡ Bolt Opt: Replaced new Map(array.map()) with for...of to avoid O(N) intermediate array allocation
       const currentLabelNamesMap = new Map<number, string>();
       for (const l of currentTask.labels) {
-        currentLabelNamesMap.set(l.id, l.name || "Unknown");
+        if (l.id !== null) {
+          currentLabelNamesMap.set(l.id, l.name || "Unknown");
+        }
       }
 
       const labelsToFetch = newLabelIds.filter(id => !currentLabelNamesMap.has(id));


### PR DESCRIPTION
💡 **What:** Replaced the `new Map(array.map(...))` initialization in `src/lib/actions/tasks/mutations.ts` with an empty Map instantiation populated via a single-pass `for...of` loop.
🎯 **Why:** Creating a `Map` by passing it a mapped array (`currentTask.labels.map((l) => [l.id, l.name])`) allocates an intermediate array of tuples in memory just for the constructor to iterate over it and discard it. This causes unnecessary garbage collection pressure during the critical `updateTaskImpl` path, which is heavily invoked during synchronization operations.
📊 **Impact:** Eliminates 1 intermediate array allocation per task update that modifies labels.
🔬 **Measurement:** Verify tests run successfully using `bun test src/lib/actions/tasks/mutations.security.test.ts src/test/integration/task-flow.test.ts` to ensure the Map is populated correctly.

---
*PR created automatically by Jules for task [2821590600610748291](https://jules.google.com/task/2821590600610748291) started by @lassestilvang*