### PR TITLE
🎨 Palette: Improve accessibility of search empty states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -293,3 +293,7 @@
 ## 2024-05-25 - Activity Log Empty State Accessibility
 **Learning:** Screen readers won't automatically announce dynamically rendered empty states (like "No activity found") when a user types a search query or applies a filter that yields no results.
 **Action:** Always add `role="status"` and `aria-live="polite"` to the wrapper container of dynamically rendered empty states so screen readers immediately announce the change. For custom or icon-only buttons inside the empty state, ensure they have an explicit `aria-label` and appropriate `focus-visible` classes; standard `Button` components already handle these out of the box.
+
+## 2025-02-12 - [Add ARIA live regions to search empty states]
+**Learning:** Dynamically rendered empty states (like search results returning no data) require `role="status"` and `aria-live="polite"` so screen readers announce the state change without shifting focus.
+**Action:** When implementing filtering or search interfaces, ensure the 'no results' container uses live regions to communicate the state clearly to non-visual users.

--- a/src/components/search/SearchPageClient.tsx
+++ b/src/components/search/SearchPageClient.tsx
@@ -213,7 +213,7 @@ export function SearchPageClient({
                                 ))}
                             </div>
                         ) : (
-                            <p className="text-sm text-muted-foreground py-4">No tasks found.</p>
+                            <p className="text-sm text-muted-foreground py-4" role="status" aria-live="polite">No tasks found.</p>
                         )}
 
                         {hasMore && <div ref={sentinelRef} className="flex justify-center py-4"><Loader2 className="h-5 w-5 animate-spin text-muted-foreground" /></div>}
@@ -221,7 +221,7 @@ export function SearchPageClient({
                     </section>
                 </div>
             ) : (
-                <div className="h-full flex flex-col items-center justify-center text-muted-foreground p-8">
+                <div className="h-full flex flex-col items-center justify-center text-muted-foreground p-8" role="status" aria-live="polite">
                     <Search className="w-12 h-12 mb-4 opacity-20" />
                     <p className="text-lg font-medium">No results found</p>
                     <p className="text-sm">Try adjusting your search or filters</p>


### PR DESCRIPTION
This PR introduces a small UX/accessibility enhancement to the Search page (`SearchPageClient.tsx`).

### 💡 What
Added `role="status"` and `aria-live="polite"` attributes to the empty state text/containers that appear when a search yields no results or no tasks.

### 🎯 Why
When a screen reader user types a query or applies a filter that results in no matches, the UI dynamically updates to show a "No results found" message. Without `aria-live`, the screen reader remains silent, leaving the user unaware of the search outcome unless they manually navigate through the DOM to find the message. By making these regions "live," the browser automatically announces the state change, making the interface far more intuitive.

### ♿ Accessibility
- `role="status"`: Identifies the element as a container for advisory information.
- `aria-live="polite"`: Instructs the screen reader to announce the update at the next graceful opportunity, without interrupting the user's current task (e.g., typing).

---
*PR created automatically by Jules for task [5393732625166864296](https://jules.google.com/task/5393732625166864296) started by @lassestilvang*