### PR TITLE
🎨 Palette: Add tooltips to icon-only buttons in SearchFiltersPanel

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
+## 2024-05-30 - Added Explicit Label Associations to Custom Inputs
+**Learning:** For custom inputs (like Radix UI Select triggers or standard textareas), using a semantic <label> without an htmlFor attribute fails to associate the label with the input. This prevents screen readers from announcing the label when the input receives focus and prevents the browser from transferring focus when the label is clicked.
+**Action:** When building or modifying custom form controls, always generate a unique ID (e.g., using React.useId()) and pass it to the input/trigger, then link the <label> using htmlFor. Adding a cursor-pointer class to the label provides immediate visual feedback that it is interactive.
+
 ## 2024-05-14 - [Added Tooltips to Icon-Only Filter Badges]
-**Learning:** Icon-only buttons (like `X` to remove filters) within complex badge components often lack tooltips, leaving sighted users without context for what the button does until they click it.
-**Action:** Use the `Tooltip` component (wrapping `TooltipTrigger asChild` around the `button`) for all icon-only action buttons to improve visual accessibility, ensuring it does not break flexbox layouts.
+**Learning:** Icon-only buttons (like "X" to remove filters) within complex badge components often lack tooltips, leaving sighted users without context for what the button does until they click it.
+**Action:** Use the Tooltip component (wrapping TooltipTrigger asChild around the button) for all icon-only action buttons to improve visual accessibility, ensuring it does not break flexbox layouts.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,3 @@
-## 2024-05-30 - Added Explicit Label Associations to Custom Inputs
-**Learning:** For custom inputs (like Radix UI Select triggers or standard textareas), using a semantic `<label>` without an `htmlFor` attribute fails to associate the label with the input. This prevents screen readers from announcing the label when the input receives focus and prevents the browser from transferring focus when the label is clicked.
-**Action:** When building or modifying custom form controls, always generate a unique ID (e.g., using `React.useId()`) and pass it to the input/trigger, then link the `<label>` using `htmlFor`. Adding a `cursor-pointer` class to the label provides immediate visual feedback that it is interactive.
+## 2024-05-14 - [Added Tooltips to Icon-Only Filter Badges]
+**Learning:** Icon-only buttons (like `X` to remove filters) within complex badge components often lack tooltips, leaving sighted users without context for what the button does until they click it.
+**Action:** Use the `Tooltip` component (wrapping `TooltipTrigger asChild` around the `button`) for all icon-only action buttons to improve visual accessibility, ensuring it does not break flexbox layouts.

--- a/src/components/search/SearchFiltersPanel.tsx
+++ b/src/components/search/SearchFiltersPanel.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   Select,
   SelectContent,
@@ -130,39 +131,54 @@ export function SearchFiltersPanel({
           <Badge variant="secondary" className="gap-1">
             <FolderOpen className="h-3 w-3" />
             {listMap.get(filters.listId) ?? "List"}
-            <button
-              onClick={() => onUpdateFilter("listId", undefined)}
-              className="ml-1 hover:text-foreground focus-visible:outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] rounded-full"
-              aria-label="Remove list filter"
-            >
-              <X className="h-3 w-3" />
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => onUpdateFilter("listId", undefined)}
+                  className="ml-1 hover:text-foreground focus-visible:outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] rounded-full"
+                  aria-label="Remove list filter"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Remove list filter</TooltipContent>
+            </Tooltip>
           </Badge>
         )}
         {filters.labelId && (
           <Badge variant="secondary" className="gap-1">
             <Tag className="h-3 w-3" />
             {labelMap.get(filters.labelId) ?? "Label"}
-            <button
-              onClick={() => onUpdateFilter("labelId", undefined)}
-              className="ml-1 hover:text-foreground focus-visible:outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] rounded-full"
-              aria-label="Remove label filter"
-            >
-              <X className="h-3 w-3" />
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => onUpdateFilter("labelId", undefined)}
+                  className="ml-1 hover:text-foreground focus-visible:outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] rounded-full"
+                  aria-label="Remove label filter"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Remove label filter</TooltipContent>
+            </Tooltip>
           </Badge>
         )}
         {filters.priority && (
           <Badge variant="secondary" className="gap-1">
             <AlertCircle className="h-3 w-3" />
             {filters.priority}
-            <button
-              onClick={() => onUpdateFilter("priority", undefined)}
-              className="ml-1 hover:text-foreground focus-visible:outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] rounded-full"
-              aria-label="Remove priority filter"
-            >
-              <X className="h-3 w-3" />
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => onUpdateFilter("priority", undefined)}
+                  className="ml-1 hover:text-foreground focus-visible:outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] rounded-full"
+                  aria-label="Remove priority filter"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Remove priority filter</TooltipContent>
+            </Tooltip>
           </Badge>
         )}
         {filters.status && filters.status !== "all" && (
@@ -173,13 +189,18 @@ export function SearchFiltersPanel({
               <Circle className="h-3 w-3" />
             )}
             {filters.status}
-            <button
-              onClick={() => onUpdateFilter("status", undefined)}
-              className="ml-1 hover:text-foreground focus-visible:outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] rounded-full"
-              aria-label="Remove status filter"
-            >
-              <X className="h-3 w-3" />
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => onUpdateFilter("status", undefined)}
+                  className="ml-1 hover:text-foreground focus-visible:outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] rounded-full"
+                  aria-label="Remove status filter"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Remove status filter</TooltipContent>
+            </Tooltip>
           </Badge>
         )}
       </div>


### PR DESCRIPTION
🎨 Palette: Add Tooltips to Icon-Only Filter Badges

💡 **What:** Added shadcn UI `Tooltip` wrappers to the icon-only "remove filter" buttons (`X`) inside the `SearchFiltersPanel` active filter badges.
🎯 **Why:** To improve micro-UX by providing sighted users with visual context for what the icon-only buttons do before they click them, aligning with accessibility best practices.
♿ **Accessibility:** Sighted users now get a tooltip explaining the action (e.g., "Remove list filter"). Screen reader users already had `aria-label`s, but this ensures a consistent experience for all users. The layout is perfectly preserved by using the `asChild` pattern.

---
*PR created automatically by Jules for task [5451611522678879561](https://jules.google.com/task/5451611522678879561) started by @lassestilvang*