### PR TITLE
⚡ Bolt: Optimize array allocation in useMemo hooks in Calendar5Client

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-31 - [Array Allocation in useMemo]
 **Learning:** Precomputing a dynamically mapped array (using `Array.map`) inside a `useMemo` hook does not prevent array re-allocation on every render if the dependency array relies on referential equality and is unstable (e.g. source arrays that might be re-created). The mapping operation allocates intermediate arrays which are collected by the garbage collector, slightly degrading performance.
 **Action:** Replace `Array.map` with a pre-allocated array (`new Array(length)`) and populate it directly using a standard `for` loop inside critical `useMemo` hooks (e.g., `daysWithMeta` in calendar components) to minimize memory allocation and garbage collection overhead.
+## 2024-05-31 - [Array Allocation in useMemo]
+**Learning:** When building an array from an existing collection (e.g., generating select options or filters), using the spread operator with `.map()` (e.g., `[defaultItem, ...items.map(...)]`) creates intermediate arrays and spread overhead.
+**Action:** Replace spread with `.map()` with a pre-allocated array to its exact final size (e.g., `new Array(items.length + 1)`) and populate it directly using a standard `for` loop to minimize memory allocation and garbage collection overhead, especially in frequently re-rendered components.

--- a/src/components/calendar5/Calendar5Client.tsx
+++ b/src/components/calendar5/Calendar5Client.tsx
@@ -140,10 +140,16 @@ export function Calendar5Client({ initialTasks, initialLists }: Calendar5ClientP
     [listMap, initialLists]
   );
 
-  const availableCalendarIds = useMemo(
-    () => [UNASSIGNED_CALENDAR_ID, ...lists.map((list) => String(list.id))],
-    [lists]
-  );
+  const availableCalendarIds = useMemo(() => {
+    // ⚡ Bolt Opt: Replaced spread with .map() with a pre-allocated array and for-loop
+    // to avoid intermediate array allocation and spread overhead.
+    const result = new Array(lists.length + 1);
+    result[0] = UNASSIGNED_CALENDAR_ID;
+    for (let i = 0; i < lists.length; i++) {
+      result[i + 1] = String(lists[i].id);
+    }
+    return result;
+  }, [lists]);
 
   useEffect(() => {
     setActiveCalendarIds((prev) => {
@@ -172,23 +178,27 @@ export function Calendar5Client({ initialTasks, initialLists }: Calendar5ClientP
     return nextMap;
   }, [lists]);
 
-  const calendarFilters = useMemo<CalendarFilterItem[]>(
-    () => [
-      {
-        id: UNASSIGNED_CALENDAR_ID,
-        label: "Unassigned",
-        color: FALLBACK_COLOR,
-        active: activeCalendarIds.has(UNASSIGNED_CALENDAR_ID),
-      },
-      ...lists.map((list) => ({
+  const calendarFilters = useMemo<CalendarFilterItem[]>(() => {
+    // ⚡ Bolt Opt: Replaced spread with .map() with a pre-allocated array and for-loop
+    // to avoid intermediate array allocation and spread overhead.
+    const result = new Array<CalendarFilterItem>(lists.length + 1);
+    result[0] = {
+      id: UNASSIGNED_CALENDAR_ID,
+      label: "Unassigned",
+      color: FALLBACK_COLOR,
+      active: activeCalendarIds.has(UNASSIGNED_CALENDAR_ID),
+    };
+    for (let i = 0; i < lists.length; i++) {
+      const list = lists[i];
+      result[i + 1] = {
         id: String(list.id),
         label: list.name,
         color: list.color ?? FALLBACK_COLOR,
         active: activeCalendarIds.has(String(list.id)),
-      })),
-    ],
-    [activeCalendarIds, lists]
-  );
+      };
+    }
+    return result;
+  }, [lists, activeCalendarIds]);
 
   const events = useMemo<CalendarEvent[]>(() => {
     // ⚡ Bolt Opt: Replaced .filter().flatMap() chain with a single O(N) loop


### PR DESCRIPTION
💡 What: Replaced spread operators and `.map()` with pre-allocated arrays and `for` loops in the `availableCalendarIds` and `calendarFilters` `useMemo` hooks within `Calendar5Client.tsx`.
🎯 Why: To avoid allocating intermediate arrays and remove the spread operator overhead, decreasing garbage collection pressure during component re-renders.
📊 Impact: Reduces memory allocation and garbage collection overhead slightly for each re-render of the `Calendar5Client` component.
🔬 Measurement: Verified with `bun test` and `bun run lint` to ensure functional equivalence. Code review confirms this is a safe optimization without sacrificing readability.

---
*PR created automatically by Jules for task [18047611391176098794](https://jules.google.com/task/18047611391176098794) started by @lassestilvang*