### PR TITLE
🎨 Palette: Semantic Form Labels for Sync Mappings

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-14 - [Added Tooltips to Icon-Only Filter Badges]
 **Learning:** Icon-only buttons (like "X" to remove filters) within complex badge components often lack tooltips, leaving sighted users without context for what the button does until they click it.
 **Action:** Use the Tooltip component (wrapping TooltipTrigger asChild around the button) for all icon-only action buttons to improve visual accessibility, ensuring it does not break flexbox layouts.
+
+## 2024-06-05 - Avoid using aria-labelledby with un-IDed elements
+**Learning:** Using `aria-labelledby` inside mapping loops while providing the targeted ID to an element, but forgetting to actually define the `id` on that target element breaks screen readers.
+**Action:** Always verify that an `id` actually exists for elements that use `aria-labelledby`, or prefer wrapping `label htmlFor` natively when working with Radix UI to allow Radix UI to manage associations.

--- a/src/components/settings/GoogleTasksMappingForm.tsx
+++ b/src/components/settings/GoogleTasksMappingForm.tsx
@@ -142,7 +142,9 @@ export function GoogleTasksMappingForm() {
             <div className="space-y-3">
                 {sortedTasklists.map((tasklist) => (
                     <div key={tasklist.id} className="flex flex-col gap-2 md:flex-row md:items-center">
-                        <div className="w-full md:w-56 text-sm text-muted-foreground">{tasklist.title}</div>
+                        <label htmlFor={`tasklist-select-${tasklist.id}`} className="w-full md:w-56 text-sm text-muted-foreground cursor-pointer">
+                            {tasklist.title}
+                        </label>
                         <Select
                             value={listMappings[tasklist.id] ? String(listMappings[tasklist.id]) : "none"}
                             onValueChange={(value) => {
@@ -155,7 +157,7 @@ export function GoogleTasksMappingForm() {
                                 });
                             }}
                         >
-                            <SelectTrigger className="w-full md:w-60" aria-labelledby={`label-${tasklist.id}`}>
+                            <SelectTrigger id={`tasklist-select-${tasklist.id}`} className="w-full md:w-60">
                                 <SelectValue placeholder="Select list" />
                             </SelectTrigger>
                             <SelectContent>

--- a/src/components/settings/TodoistMappingForm.tsx
+++ b/src/components/settings/TodoistMappingForm.tsx
@@ -310,7 +310,9 @@ export function TodoistMappingForm() {
                 <div className="mt-4 space-y-3">
                     {projects.map((project) => (
                         <div key={project.id} className="flex flex-col gap-2 md:flex-row md:items-center">
-                            <div className="w-full md:w-48 text-sm text-muted-foreground">{project.name}</div>
+                            <label htmlFor={`project-select-${project.id}`} className="w-full md:w-48 text-sm text-muted-foreground cursor-pointer">
+                                {project.name}
+                            </label>
                             <Select
                                 value={toSelectValue(projectMappings[project.id])}
                                 onValueChange={(value) => {
@@ -323,7 +325,7 @@ export function TodoistMappingForm() {
                                     });
                                 }}
                             >
-                                <SelectTrigger className="w-full md:w-60" aria-labelledby={`project-label-${project.id}`}>
+                                <SelectTrigger id={`project-select-${project.id}`} className="w-full md:w-60">
                                     <SelectValue placeholder="Select list" />
                                 </SelectTrigger>
                                 <SelectContent>
@@ -349,7 +351,9 @@ export function TodoistMappingForm() {
                 <div className="mt-4 space-y-3">
                     {labels.map((label) => (
                         <div key={label.id} className="flex flex-col gap-2 md:flex-row md:items-center">
-                            <div className="w-full md:w-48 text-sm text-muted-foreground">{label.name}</div>
+                            <label htmlFor={`label-select-${label.id}`} className="w-full md:w-48 text-sm text-muted-foreground cursor-pointer">
+                                {label.name}
+                            </label>
                             <Select
                                 value={toSelectValue(labelMappings[label.id])}
                                 onValueChange={(value) => {
@@ -362,7 +366,7 @@ export function TodoistMappingForm() {
                                     });
                                 }}
                             >
-                                <SelectTrigger className="w-full md:w-60" aria-labelledby={`label-label-${label.id}`}>
+                                <SelectTrigger id={`label-select-${label.id}`} className="w-full md:w-60">
                                     <SelectValue placeholder="Select list" />
                                 </SelectTrigger>
                                 <SelectContent>


### PR DESCRIPTION
💡 **What:** Refactored label mappings in `TodoistMappingForm` and `GoogleTasksMappingForm` to use the correct `label htmlFor` accessible pattern.
🎯 **Why:** The previous elements were using `div` tags with no interactive characteristics, and were missing `id` tags to match `SelectTrigger`'s `aria-labelledby`, completely breaking screen readers for the configuration dropdowns.
♿ **Accessibility:** Replaces `aria-labelledby` with native HTML `label htmlFor` and explicitly binds unique deterministic IDs to the respective mapped elements. Clicking the label text now correctly forwards focus to the `SelectTrigger` components.

---
*PR created automatically by Jules for task [8975557897756333056](https://jules.google.com/task/8975557897756333056) started by @lassestilvang*