### PR TITLE
🎨 Palette: Add type="button" to custom action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-14 - [Added Tooltips to Icon-Only Filter Badges]
 **Learning:** Icon-only buttons (like "X" to remove filters) within complex badge components often lack tooltips, leaving sighted users without context for what the button does until they click it.
 **Action:** Use the Tooltip component (wrapping TooltipTrigger asChild around the button) for all icon-only action buttons to improve visual accessibility, ensuring it does not break flexbox layouts.
+
+## 2026-06-03 - Always set type="button" on custom action buttons
+**Learning:** Custom UI action buttons (like those used for filter removal or timer modes) can inadvertently cause form submissions or full-page reloads if they lack a `type` attribute, as the default HTML behavior for `<button>` is `type="submit"`.
+**Action:** Always explicitly specify `type="button"` on custom `<button>` elements that act as standalone UI controls, unless they are intentionally designed to submit a form.

--- a/src/components/search/SearchFiltersPanel.tsx
+++ b/src/components/search/SearchFiltersPanel.tsx
@@ -134,6 +134,7 @@ export function SearchFiltersPanel({
             <Tooltip>
               <TooltipTrigger asChild>
                 <button
+                  type="button"
                   onClick={() => onUpdateFilter("listId", undefined)}
                   className="ml-1 hover:text-foreground focus-visible:outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] rounded-full"
                   aria-label="Remove list filter"
@@ -152,6 +153,7 @@ export function SearchFiltersPanel({
             <Tooltip>
               <TooltipTrigger asChild>
                 <button
+                  type="button"
                   onClick={() => onUpdateFilter("labelId", undefined)}
                   className="ml-1 hover:text-foreground focus-visible:outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] rounded-full"
                   aria-label="Remove label filter"
@@ -170,6 +172,7 @@ export function SearchFiltersPanel({
             <Tooltip>
               <TooltipTrigger asChild>
                 <button
+                  type="button"
                   onClick={() => onUpdateFilter("priority", undefined)}
                   className="ml-1 hover:text-foreground focus-visible:outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] rounded-full"
                   aria-label="Remove priority filter"
@@ -192,6 +195,7 @@ export function SearchFiltersPanel({
             <Tooltip>
               <TooltipTrigger asChild>
                 <button
+                  type="button"
                   onClick={() => onUpdateFilter("status", undefined)}
                   className="ml-1 hover:text-foreground focus-visible:outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] rounded-full"
                   aria-label="Remove status filter"

--- a/src/components/tasks/PomodoroTimer.tsx
+++ b/src/components/tasks/PomodoroTimer.tsx
@@ -82,6 +82,7 @@ export function PomodoroTimer() {
                 {(Object.keys(MODES) as TimerMode[]).map((m) => (
                     <button
                         key={m}
+                        type="button"
                         onClick={() => handleModeChange(m)}
                         className={cn(
                             "flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background",

--- a/update_palette_journal.py
+++ b/update_palette_journal.py
@@ -1,0 +1,23 @@
+import os
+from datetime import datetime
+
+journal_dir = ".jules"
+journal_path = os.path.join(journal_dir, "palette.md")
+
+if not os.path.exists(journal_dir):
+    os.makedirs(journal_dir)
+
+today = datetime.now().strftime("%Y-%m-%d")
+entry = f"""## {today} - Always set type="button" on custom action buttons
+**Learning:** Custom UI action buttons (like those used for filter removal or timer modes) can inadvertently cause form submissions or full-page reloads if they lack a `type` attribute, as the default HTML behavior for `<button>` is `type="submit"`.
+**Action:** Always explicitly specify `type="button"` on custom `<button>` elements that act as standalone UI controls, unless they are intentionally designed to submit a form.
+"""
+
+if os.path.exists(journal_path):
+    with open(journal_path, "a") as f:
+        f.write("\n" + entry)
+else:
+    with open(journal_path, "w") as f:
+        f.write(entry)
+
+print("Journal updated successfully.")

--- a/update_palette_journal.py
+++ b/update_palette_journal.py
@@ -14,10 +14,10 @@ entry = f"""## {today} - Always set type="button" on custom action buttons
 """
 
 if os.path.exists(journal_path):
-    with open(journal_path, "a") as f:
+    with open(journal_path, "a", encoding="utf-8") as f:
         f.write("\n" + entry)
 else:
-    with open(journal_path, "w") as f:
+    with open(journal_path, "w", encoding="utf-8") as f:
         f.write(entry)
 
 print("Journal updated successfully.")


### PR DESCRIPTION
This PR adds the explicit `type="button"` attribute to custom HTML `<button>` elements in `SearchFiltersPanel.tsx` and `PomodoroTimer.tsx`.

💡 **What**: Added `type="button"` to the filter removal `X` buttons and the timer mode toggle buttons.
🎯 **Why**: By default, HTML buttons act as submit buttons. If these components were ever nested within a form, clicking them would inadvertently submit the form and cause a page reload. Specifying `type="button"` ensures they only trigger their bound client-side onClick handlers.
♿ **Accessibility/UX**: This is a robust standard that prevents unexpected and disruptive page behavior, improving overall reliability.

---
*PR created automatically by Jules for task [2912818200945825804](https://jules.google.com/task/2912818200945825804) started by @lassestilvang*