### PR TITLE
🛡️ Sentinel: [HIGH] Fix IP spoofing vulnerability in getClientIp

### DIFF
--- a/src/lib/ip-utils.test.ts
+++ b/src/lib/ip-utils.test.ts
@@ -61,37 +61,12 @@ describe("getClientIp", () => {
     expect(getClientIp(headers)).toBe("2.2.2.2");
   });
 
-  it("prioritizes x-real-ip over x-forwarded-for", () => {
+  it("returns null when only spoofable headers are present", () => {
     const headers = new Headers();
     headers.set("x-real-ip", "3.3.3.3");
     headers.set("x-forwarded-for", "4.4.4.4");
-    expect(getClientIp(headers)).toBe("3.3.3.3");
-  });
-
-  it("falls back to x-client-ip before x-forwarded-for", () => {
-    const headers = new Headers();
-    headers.set("x-client-ip", "3.3.3.3");
-    headers.set("x-forwarded-for", "4.4.4.4");
-    expect(getClientIp(headers)).toBe("3.3.3.3");
-  });
-
-  it("falls back to x-forwarded-for last", () => {
-    const headers = new Headers();
-    headers.set("x-forwarded-for", "4.4.4.4");
-    expect(getClientIp(headers)).toBe("4.4.4.4");
-  });
-
-  it("handles x-forwarded-for with multiple IPs (takes first)", () => {
-    const headers = new Headers();
-    headers.set("x-forwarded-for", "4.4.4.4, 5.5.5.5");
-    expect(getClientIp(headers)).toBe("4.4.4.4");
-  });
-
-  it("handles spoofing attempt where x-real-ip is present", () => {
-    const headers = new Headers();
-    headers.set("x-forwarded-for", "spoofed, 5.5.5.5");
-    headers.set("x-real-ip", "6.6.6.6");
-    expect(getClientIp(headers)).toBe("6.6.6.6");
+    headers.set("x-client-ip", "5.5.5.5");
+    expect(getClientIp(headers)).toBeNull();
   });
 
   it("returns null if no headers present", () => {

--- a/src/lib/ip-utils.ts
+++ b/src/lib/ip-utils.ts
@@ -40,16 +40,11 @@ interface HeaderStore {
  * Priority:
  * 1. x-vercel-ip (Vercel/Edge specific, set by platform)
  * 2. x-vercel-forwarded-for (Vercel specific, trusted)
- * 3. x-real-ip (Nginx/load balancers, usually trusted)
- * 4. x-client-ip (Standard)
- * 5. x-forwarded-for (Standard but spoofable if not careful)
  */
 export function getClientIp(headers: HeaderStore | null | undefined): string | null {
   if (!headers || typeof headers.get !== "function") {
     return null;
   }
-
-  const isProduction = process.env.NODE_ENV === "production";
 
   const vercelIp = headers.get("x-vercel-ip");
   if (vercelIp) {
@@ -59,25 +54,6 @@ export function getClientIp(headers: HeaderStore | null | undefined): string | n
   const vercelForwardedFor = headers.get("x-vercel-forwarded-for");
   if (vercelForwardedFor) {
     return normalizeIp(vercelForwardedFor);
-  }
-
-  if (isProduction) {
-    return null;
-  }
-
-  const realIp = headers.get("x-real-ip");
-  if (realIp) {
-    return normalizeIp(realIp);
-  }
-
-  const clientIp = headers.get("x-client-ip");
-  if (clientIp) {
-    return normalizeIp(clientIp);
-  }
-
-  const forwardedFor = headers.get("x-forwarded-for");
-  if (forwardedFor) {
-    return normalizeIp(forwardedFor);
   }
 
   return null;


### PR DESCRIPTION
Fixes an authentication bypass vulnerability where spoofable HTTP headers were trusted for IP-based allowlisting.

---
*PR created automatically by Jules for task [7658974273262492419](https://jules.google.com/task/7658974273262492419) started by @lassestilvang*