### PR TITLE
🛡️ Sentinel: Sanitize database error logs

### DIFF
--- a/src/lib/action-result.ts
+++ b/src/lib/action-result.ts
@@ -286,7 +286,7 @@ export function withErrorHandling<T, Args extends unknown[]>(
 
       // 5. Generic error for unexpected exceptions
       // Log the sanitized error for debugging purposes on the server
-      console.error("[ServerError] Unexpected error in Server Action:", sanitizeError(error));
+      console.error("[ServerError] Unexpected error in Server Action:", sanitizeError(error instanceof Error ? error.stack ?? error.message : error));
 
       return failure({
         code: "UNKNOWN_ERROR",

--- a/src/lib/action-result.ts
+++ b/src/lib/action-result.ts
@@ -285,8 +285,8 @@ export function withErrorHandling<T, Args extends unknown[]>(
       }
 
       // 5. Generic error for unexpected exceptions
-      // Log the original error for debugging purposes on the server
-      console.error("[ServerError] Unexpected error in Server Action:", error);
+      // Log the sanitized error for debugging purposes on the server
+      console.error("[ServerError] Unexpected error in Server Action:", sanitizeError(error));
 
       return failure({
         code: "UNKNOWN_ERROR",

--- a/src/lib/actions/task-safe.ts
+++ b/src/lib/actions/task-safe.ts
@@ -304,7 +304,7 @@ export async function toggleTaskCompletionSafe(
       });
     }
 
-    console.error("[Server Action Error]", sanitizeError(error));
+    console.error("[Server Action Error]", sanitizeError(error instanceof Error ? error.stack ?? error.message : error));
     return failure({
       code: "UNKNOWN_ERROR",
       message: "An unexpected error occurred. Please try again.",

--- a/src/lib/actions/task-safe.ts
+++ b/src/lib/actions/task-safe.ts
@@ -86,7 +86,7 @@ export async function createTaskSafe(
       });
     }
 
-    console.error("[Server Action Error]", sanitizeError(error));
+    console.error("[Server Action Error]", sanitizeError(error instanceof Error ? error.stack ?? error.message : error));
     return failure({
       code: "UNKNOWN_ERROR",
       message: "An unexpected error occurred. Please try again.",

--- a/src/lib/actions/task-safe.ts
+++ b/src/lib/actions/task-safe.ts
@@ -79,7 +79,7 @@ export async function createTaskSafe(
         error.message.includes("database") ||
         error.message.includes("constraint"))
     ) {
-      console.error("[Database Error]", sanitizeError(error));
+      console.error("[Database Error]", sanitizeError(error.stack ?? error.message));
       return failure({
         code: "DATABASE_ERROR",
         message: "Unable to create task. Please try again.",

--- a/src/lib/actions/task-safe.ts
+++ b/src/lib/actions/task-safe.ts
@@ -12,6 +12,7 @@ import {
   ValidationError,
   AuthorizationError,
   NotFoundError,
+  sanitizeError,
 } from "../action-result";
 import { getTask, createTask, updateTask, deleteTask, toggleTaskCompletion } from "./tasks";
 
@@ -78,14 +79,14 @@ export async function createTaskSafe(
         error.message.includes("database") ||
         error.message.includes("constraint"))
     ) {
-      console.error("[Database Error]", error.message);
+      console.error("[Database Error]", sanitizeError(error));
       return failure({
         code: "DATABASE_ERROR",
         message: "Unable to create task. Please try again.",
       });
     }
 
-    console.error("[Server Action Error]", error);
+    console.error("[Server Action Error]", sanitizeError(error));
     return failure({
       code: "UNKNOWN_ERROR",
       message: "An unexpected error occurred. Please try again.",
@@ -165,14 +166,14 @@ export async function updateTaskSafe(
         error.message.includes("database") ||
         error.message.includes("constraint"))
     ) {
-      console.error("[Database Error]", error.message);
+      console.error("[Database Error]", sanitizeError(error));
       return failure({
         code: "DATABASE_ERROR",
         message: "Unable to update task. Please try again.",
       });
     }
 
-    console.error("[Server Action Error]", error);
+    console.error("[Server Action Error]", sanitizeError(error));
     return failure({
       code: "UNKNOWN_ERROR",
       message: "An unexpected error occurred. Please try again.",
@@ -228,14 +229,14 @@ export async function deleteTaskSafe(
         error.message.includes("database") ||
         error.message.includes("constraint"))
     ) {
-      console.error("[Database Error]", error.message);
+      console.error("[Database Error]", sanitizeError(error));
       return failure({
         code: "DATABASE_ERROR",
         message: "Unable to delete task. Please try again.",
       });
     }
 
-    console.error("[Server Action Error]", error);
+    console.error("[Server Action Error]", sanitizeError(error));
     return failure({
       code: "UNKNOWN_ERROR",
       message: "An unexpected error occurred. Please try again.",
@@ -296,14 +297,14 @@ export async function toggleTaskCompletionSafe(
         error.message.includes("database") ||
         error.message.includes("constraint"))
     ) {
-      console.error("[Database Error]", error.message);
+      console.error("[Database Error]", sanitizeError(error));
       return failure({
         code: "DATABASE_ERROR",
         message: "Unable to update task completion. Please try again.",
       });
     }
 
-    console.error("[Server Action Error]", error);
+    console.error("[Server Action Error]", sanitizeError(error));
     return failure({
       code: "UNKNOWN_ERROR",
       message: "An unexpected error occurred. Please try again.",

--- a/src/lib/actions/task-safe.ts
+++ b/src/lib/actions/task-safe.ts
@@ -166,7 +166,7 @@ export async function updateTaskSafe(
         error.message.includes("database") ||
         error.message.includes("constraint"))
     ) {
-      console.error("[Database Error]", sanitizeError(error));
+      console.error("[Database Error]", sanitizeError(error.stack ?? error.message));
       return failure({
         code: "DATABASE_ERROR",
         message: "Unable to update task. Please try again.",

--- a/src/lib/actions/task-safe.ts
+++ b/src/lib/actions/task-safe.ts
@@ -173,7 +173,7 @@ export async function updateTaskSafe(
       });
     }
 
-    console.error("[Server Action Error]", sanitizeError(error));
+    console.error("[Server Action Error]", sanitizeError(error instanceof Error ? error.stack ?? error.message : error));
     return failure({
       code: "UNKNOWN_ERROR",
       message: "An unexpected error occurred. Please try again.",

--- a/src/lib/actions/task-safe.ts
+++ b/src/lib/actions/task-safe.ts
@@ -236,7 +236,7 @@ export async function deleteTaskSafe(
       });
     }
 
-    console.error("[Server Action Error]", sanitizeError(error));
+    console.error("[Server Action Error]", sanitizeError(error instanceof Error ? error.stack ?? error.message : error));
     return failure({
       code: "UNKNOWN_ERROR",
       message: "An unexpected error occurred. Please try again.",

--- a/src/lib/actions/task-safe.ts
+++ b/src/lib/actions/task-safe.ts
@@ -297,7 +297,7 @@ export async function toggleTaskCompletionSafe(
         error.message.includes("database") ||
         error.message.includes("constraint"))
     ) {
-      console.error("[Database Error]", sanitizeError(error));
+      console.error("[Database Error]", sanitizeError(error.stack ?? error.message));
       return failure({
         code: "DATABASE_ERROR",
         message: "Unable to update task completion. Please try again.",

--- a/src/lib/actions/task-safe.ts
+++ b/src/lib/actions/task-safe.ts
@@ -229,7 +229,7 @@ export async function deleteTaskSafe(
         error.message.includes("database") ||
         error.message.includes("constraint"))
     ) {
-      console.error("[Database Error]", sanitizeError(error));
+      console.error("[Database Error]", sanitizeError(error.stack ?? error.message));
       return failure({
         code: "DATABASE_ERROR",
         message: "Unable to delete task. Please try again.",


### PR DESCRIPTION
🛡️ Sentinel: Sanitize database error logs

* Ensure errors are passed through `sanitizeError` in `src/lib/action-result.ts` and `src/lib/actions/task-safe.ts` before logging them to `console.error`.
* This prevents potential leakage of sensitive data (such as raw payloads or database connection strings from Prisma/Drizzle on error) into system logs.

---
*PR created automatically by Jules for task [7176537191167406643](https://jules.google.com/task/7176537191167406643) started by @lassestilvang*