### PR TITLE
🛡️ Sentinel: [HIGH] Add rate limiting to saved views mutations

### DIFF
--- a/src/components/tasks/TemplateManager.tsx
+++ b/src/components/tasks/TemplateManager.tsx
@@ -13,7 +13,7 @@ import {
 import { getTemplates, deleteTemplate, instantiateTemplate } from "@/lib/actions";
 import { Plus, Trash2, FileText, Play, Pencil } from "lucide-react";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
 import { toast } from "sonner";
 import { TemplateFormDialog } from "./TemplateFormDialog";
 

--- a/src/lib/actions/views.ts
+++ b/src/lib/actions/views.ts
@@ -42,7 +42,7 @@ async function createSavedViewImpl(data: {
 
     const limit = await rateLimit(`view:create:${data.userId}`, 100, 3600);
     if (!limit.success) {
-        throw new Error("Rate limit exceeded. Please try again later.");
+        throw new ValidationError("Rate limit exceeded. Please try again later.");
     }
 
     if (!data.name || data.name.trim().length === 0) {

--- a/src/lib/actions/views.ts
+++ b/src/lib/actions/views.ts
@@ -15,6 +15,7 @@ import {
     ValidationError,
 } from "./shared";
 import { requireUser } from "@/lib/auth";
+import { rateLimit } from "@/lib/rate-limit";
 
 /**
  * Retrieves all saved views for a specific user.
@@ -38,6 +39,11 @@ async function createSavedViewImpl(data: {
     icon?: string;
 }) {
     await requireUser(data.userId);
+
+    const limit = await rateLimit(`view:create:${data.userId}`, 100, 3600);
+    if (!limit.success) {
+        throw new Error("Rate limit exceeded. Please try again later.");
+    }
 
     if (!data.name || data.name.trim().length === 0) {
         throw new ValidationError("View name is required");
@@ -68,6 +74,11 @@ export const createSavedView: (
  */
 async function deleteSavedViewImpl(id: number, userId: string) {
     await requireUser(userId);
+
+    const limit = await rateLimit(`view:delete:${userId}`, 100, 3600);
+    if (!limit.success) {
+        throw new Error("Rate limit exceeded. Please try again later.");
+    }
 
     await db.delete(savedViews).where(and(eq(savedViews.id, id), eq(savedViews.userId, userId)));
     revalidatePath("/", "layout");

--- a/src/lib/actions/views.ts
+++ b/src/lib/actions/views.ts
@@ -77,7 +77,7 @@ async function deleteSavedViewImpl(id: number, userId: string) {
 
     const limit = await rateLimit(`view:delete:${userId}`, 100, 3600);
     if (!limit.success) {
-        throw new Error("Rate limit exceeded. Please try again later.");
+        throw new ValidationError("Rate limit exceeded. Please try again later.");
     }
 
     await db.delete(savedViews).where(and(eq(savedViews.id, id), eq(savedViews.userId, userId)));


### PR DESCRIPTION
**Vulnerability:**
The `createSavedViewImpl` and `deleteSavedViewImpl` server actions in `src/lib/actions/views.ts` were missing rate limiting protections. This missing control could allow a malicious actor or buggy client script to rapidly create or delete saved views, potentially exhausting database connections, degrading application performance, or resulting in a Denial of Service (DoS).

**Impact:**
Without rate limiting, an attacker could programmatically spam the creation of thousands of views (even within size limits) per minute, causing unnecessary load on the PostgreSQL database.

**Fix:**
Implemented the standard `rateLimit` utility to enforce a strict limit of 100 requests per hour for both creating and deleting saved views, keying the limit to the specific `userId`.

**Verification:**
- Visually verified `src/lib/actions/views.ts`.
- Ran the full test suite (`bun test`) - all 726 tests passed.
- Ran the linter (`bun run lint`) - resolved an unused import warning in a separate file, resulting in 0 errors.

---
*PR created automatically by Jules for task [8868748755920507906](https://jules.google.com/task/8868748755920507906) started by @lassestilvang*