### PR TITLE
🎨 Palette: Add tooltip to remove icon button and set button type

### DIFF
--- a/src/components/tasks/create-task/TaskMetadataBar.tsx
+++ b/src/components/tasks/create-task/TaskMetadataBar.tsx
@@ -6,6 +6,11 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { Calendar as CalendarComponent } from "@/components/ui/calendar";
 import { IconPicker } from "@/components/ui/icon-picker";
 import { ResolvedIcon } from "@/components/ui/resolved-icon";
@@ -150,18 +155,25 @@ export function TaskMetadataBar({
           }
         />
         {icon && (
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8 text-muted-foreground hover:text-foreground"
-            onClick={() =>
-              dispatchState({ type: "SET_ICON", payload: undefined })
-            }
-            title="Remove icon"
-            aria-label="Remove icon"
-          >
-            <X className="h-4 w-4" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                onClick={() =>
+                  dispatchState({ type: "SET_ICON", payload: undefined })
+                }
+                aria-label="Remove icon"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Remove icon</p>
+            </TooltipContent>
+          </Tooltip>
         )}
       </div>
     </div>

--- a/src/components/tasks/create-task/TaskMetadataBar.tsx
+++ b/src/components/tasks/create-task/TaskMetadataBar.tsx
@@ -160,8 +160,8 @@ export function TaskMetadataBar({
               <Button
                 type="button"
                 variant="ghost"
-                size="icon"
-                className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                size="icon-sm"
+                className="text-muted-foreground hover:text-foreground"
                 onClick={() =>
                   dispatchState({ type: "SET_ICON", payload: undefined })
                 }

--- a/src/test/mocks-ui.tsx
+++ b/src/test/mocks-ui.tsx
@@ -30,7 +30,7 @@ export const DialogMocks = {
 
         // Some components rely on the child's onClick propagating up
         // Radix's real DialogTrigger intercepts it.
-        const childNode = React.isValidElement(children) ? children : null;
+        const childNode = React.isValidElement<{ onClick?: (e: any) => void }>(children) ? children : null;
 
         return (
             <div
@@ -38,7 +38,7 @@ export const DialogMocks = {
                 role="button"
                 tabIndex={0}
                 onClick={(e) => {
-                    if (childNode?.props.onClick) {
+                    if (childNode?.props?.onClick) {
                         childNode.props.onClick(e);
                     }
                     if (onClick) onClick(e);
@@ -47,7 +47,7 @@ export const DialogMocks = {
                 onKeyDown={(e) => {
                     if (e.key === 'Enter' || e.key === ' ') {
                         e.preventDefault();
-                        if (childNode?.props.onClick) {
+                        if (childNode?.props?.onClick) {
                             childNode.props.onClick(e);
                         }
                         if (onClick) onClick(e);


### PR DESCRIPTION
💡 **What**: Added a Tooltip around the "Remove icon" button in `TaskMetadataBar.tsx` and explicitly set its `type="button"`.
🎯 **Why**: Improves UX by showing a clear visual tooltip for the icon-only action, rather than relying on the slow, native OS title attribute. Also prevents accidental form submissions since the button previously defaulted to `type="submit"`.
♿ **Accessibility**: Retained the explicit `aria-label` for screen reader support while enhancing visual discovery for sighted users.

---
*PR created automatically by Jules for task [11850402948585368961](https://jules.google.com/task/11850402948585368961) started by @lassestilvang*