### PR TITLE
🛡️ Sentinel: [MEDIUM] Add missing rate limiting to view settings actions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -21,3 +21,7 @@
 **Vulnerability:** The Server Actions for reordering tasks (`reorderTasksImpl`), lists (`reorderListsImpl`), and labels (`reorderLabelsImpl`) lacked rate limiting.
 **Learning:** While creation and mutation endpoints are often the primary focus for rate limiting, endpoints that perform bulk operations or complex sorting (like reordering) are also vectors for DoS attacks or database exhaustion if left unprotected.
 **Prevention:** Apply the `rateLimit` utility consistently across all mutative Server Actions, regardless of whether they create new records or modify existing states like ordering.
+## 2024-06-10 - Unprotected Mutative Server Actions (Rate Limiting)
+**Vulnerability:** The `saveViewSettings` and `resetViewSettings` Server Actions were exposed without rate limiting, allowing potential DoS attacks or excessive database load via rapid successive requests.
+**Learning:** Even low-impact preference endpoints require consistent rate limiting because the computational cost (auth, DB write) still taxes the infrastructure. Overlooking "minor" endpoints creates asymmetric DoS vectors.
+**Prevention:** Always implement the codebase's standard rate limiting (e.g., `rateLimit(\`action:${userId}\`)`) on EVERY mutative Server Action, regardless of the perceived sensitivity of the data being modified.

--- a/src/lib/actions/view-settings.ts
+++ b/src/lib/actions/view-settings.ts
@@ -16,6 +16,7 @@ import {
   ValidationError,
 } from "./shared";
 import { requireUser } from "@/lib/auth";
+import { rateLimit } from "@/lib/rate-limit";
 
 /**
  * View settings configuration type.
@@ -59,6 +60,11 @@ export async function getViewSettings(userId: string, viewId: string) {
  */
 async function saveViewSettingsImpl(userId: string, viewId: string, settings: ViewSettingsConfig) {
   await requireUser(userId);
+
+  const limit = await rateLimit(`view-settings:save:${userId}`, 100, 3600);
+  if (!limit.success) {
+    throw new ValidationError("Rate limit exceeded. Please try again later.");
+  }
 
   if (!userId) {
     throw new ValidationError("User ID is required", { userId: "User ID cannot be empty" });
@@ -109,6 +115,12 @@ export const saveViewSettings: (
  */
 async function resetViewSettingsImpl(userId: string, viewId: string) {
   await requireUser(userId);
+
+  const limit = await rateLimit(`view-settings:reset:${userId}`, 100, 3600);
+  if (!limit.success) {
+    throw new ValidationError("Rate limit exceeded. Please try again later.");
+  }
+
   await db
     .delete(viewSettings)
     .where(and(eq(viewSettings.userId, userId), eq(viewSettings.viewId, viewId)));

--- a/src/lib/actions/view-settings.ts
+++ b/src/lib/actions/view-settings.ts
@@ -61,7 +61,7 @@ export async function getViewSettings(userId: string, viewId: string) {
 async function saveViewSettingsImpl(userId: string, viewId: string, settings: ViewSettingsConfig) {
   await requireUser(userId);
 
-  const limit = await rateLimit(`view-settings:save:${userId}`, 100, 3600);
+  const limit = await rateLimit(`view-settings:save:${userId}`, 100, 60);
   if (!limit.success) {
     throw new ValidationError("Rate limit exceeded. Please try again later.");
   }


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The `saveViewSettings` and `resetViewSettings` Server Actions were not protected by rate limiting.
🎯 **Impact:** Malicious actors or faulty clients could spam these endpoints to generate excessive database writes, leading to increased load or Denial of Service (DoS).
🔧 **Fix:** Added the standard `rateLimit` utility to both functions before they perform database operations.
✅ **Verification:** Ran test suite, checked code logic to ensure errors bubble up correctly.

---
*PR created automatically by Jules for task [16647204092062752073](https://jules.google.com/task/16647204092062752073) started by @lassestilvang*