### PR TITLE
🎨 Palette: [UX improvement] Add type="button" to TemplateManager action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -22,3 +22,7 @@
 ## 2024-06-06 - Always set aria-label on form inputs lacking explicit labels
 **Learning:** Some custom UI elements (like textareas for subtasks) lack explicit `<label htmlFor="...">` associations or visually hidden labels. This leaves screen reader users without context when the field receives focus.
 **Action:** When a `<label>` cannot be explicitly linked via `htmlFor`, or if the field lacks one entirely, always add an `aria-label` attribute directly to the `<Input>` or `<Textarea>` element to ensure full accessibility.
+
+## 2024-06-11 - Always Add type="button" to Component Buttons
+**Learning:** Action buttons in generic components (like Shadcn UI `<Button>`) will default to `type="submit"` if not explicitly specified. This can cause unintended form submissions or page reloads if the component is eventually embedded within a form.
+**Action:** Always explicitly set `type="button"` on all custom action buttons that are not intended to submit a form.

--- a/src/components/tasks/TemplateManager.tsx
+++ b/src/components/tasks/TemplateManager.tsx
@@ -13,7 +13,7 @@ import {
 import { getTemplates, deleteTemplate, instantiateTemplate } from "@/lib/actions";
 import { Plus, Trash2, FileText, Play, Pencil } from "lucide-react";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { toast } from "sonner";
 import { TemplateFormDialog } from "./TemplateFormDialog";
 
@@ -132,27 +132,27 @@ export function TemplateManager({ userId }: TemplateManagerProps) {
                                         </div>
                                     </div>
                                     <div className="flex gap-2">
-                                        <Button size="sm" variant="outline" onClick={() => handleInstantiate(template.id)} data-testid={`use-template-${template.id}`} aria-label={`Use template ${template.name}`}>
+                                        <Button type="button" size="sm" variant="outline" onClick={() => handleInstantiate(template.id)} data-testid={`use-template-${template.id}`} aria-label={`Use template ${template.name}`}>
                                             <Play className="h-3 w-3 mr-1" />
                                             Use
                                         </Button>
 
-                                            <Tooltip>
-                                                <TooltipTrigger asChild>
-                                                    <Button size="icon" variant="ghost" onClick={() => handleOpenEditDialog(template)} data-testid={`edit-template-${template.id}`} aria-label="Edit template">
-                                                        <Pencil className="h-4 w-4" />
-                                                    </Button>
-                                                </TooltipTrigger>
-                                                <TooltipContent>Edit template</TooltipContent>
-                                            </Tooltip>
-                                            <Tooltip>
-                                                <TooltipTrigger asChild>
-                                                    <Button size="icon" variant="ghost" onClick={() => handleDelete(template.id)} data-testid={`delete-template-${template.id}`} aria-label="Delete template">
-                                                        <Trash2 className="h-4 w-4 text-destructive" />
-                                                    </Button>
-                                                </TooltipTrigger>
-                                                <TooltipContent>Delete template</TooltipContent>
-                                            </Tooltip>
+                                        <Tooltip>
+                                            <TooltipTrigger asChild>
+                                                <Button type="button" size="icon" variant="ghost" onClick={() => handleOpenEditDialog(template)} data-testid={`edit-template-${template.id}`} aria-label="Edit template">
+                                                    <Pencil className="h-4 w-4" />
+                                                </Button>
+                                            </TooltipTrigger>
+                                            <TooltipContent>Edit template</TooltipContent>
+                                        </Tooltip>
+                                        <Tooltip>
+                                            <TooltipTrigger asChild>
+                                                <Button type="button" size="icon" variant="ghost" onClick={() => handleDelete(template.id)} data-testid={`delete-template-${template.id}`} aria-label="Delete template">
+                                                    <Trash2 className="h-4 w-4 text-destructive" />
+                                                </Button>
+                                            </TooltipTrigger>
+                                            <TooltipContent>Delete template</TooltipContent>
+                                        </Tooltip>
 
                                     </div>
                                 </div>


### PR DESCRIPTION
💡 What: Explicitly set `type="button"` on the Use, Edit, and Delete action buttons inside the TemplateManager component. Also removed an unused `TooltipProvider` import that was flagging a linter warning.
🎯 Why: HTML `<button>` elements default to `type="submit"`. If the TemplateManager component (or its parent contexts) is ever embedded within a `<form>`, interacting with these buttons could unintentionally trigger a form submission or a jarring full-page reload. Explicitly declaring them as `type="button"` ensures they remain safe, isolated UI controls.
♿ Accessibility: N/A - primarily functional safety/UX.

---
*PR created automatically by Jules for task [15561349929390019970](https://jules.google.com/task/15561349929390019970) started by @lassestilvang*