### PR TITLE
🎨 Palette: Add Tooltip for "Add List" button in SidebarLists

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -22,3 +22,7 @@
 ## 2024-06-06 - Always set aria-label on form inputs lacking explicit labels
 **Learning:** Some custom UI elements (like textareas for subtasks) lack explicit `<label htmlFor="...">` associations or visually hidden labels. This leaves screen reader users without context when the field receives focus.
 **Action:** When a `<label>` cannot be explicitly linked via `htmlFor`, or if the field lacks one entirely, always add an `aria-label` attribute directly to the `<Input>` or `<Textarea>` element to ensure full accessibility.
+
+## 2024-06-13 - [Use Custom Tooltips over Native title for Icon-only buttons]
+**Learning:** Using the native HTML `title` attribute for tooltips on icon-only action buttons results in an inconsistent visual experience, delayed appearance, and potential accessibility issues for keyboard users.
+**Action:** Replace native `title` attributes on icon-only buttons with the application's design system `<Tooltip>` component (wrapping `<TooltipTrigger asChild>`) to ensure immediate, visually consistent, and accessible feedback while maintaining the `aria-label` attribute on the button itself.

--- a/src/components/layout/sidebar/SidebarLists.tsx
+++ b/src/components/layout/sidebar/SidebarLists.tsx
@@ -243,21 +243,21 @@ function SidebarListsInner({ lists: ssrLists, userId }: SidebarListsProps) {
                             <p>{isReordering ? "Done reordering" : "Reorder lists"}</p>
                         </TooltipContent>
                     </Tooltip>
-                    <ManageListDialog
-                        trigger={
-                            <Tooltip>
+                    <Tooltip>
+                        <ManageListDialog
+                            trigger={
                                 <TooltipTrigger asChild>
                                     <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="Add List" data-testid="add-list-button">
                                         <Plus className="h-4 w-4" />
                                     </Button>
                                 </TooltipTrigger>
-                                <TooltipContent>
-                                    <p>Add List</p>
-                                </TooltipContent>
-                            </Tooltip>
-                        }
-                        userId={userId}
-                    />
+                            }
+                            userId={userId}
+                        />
+                        <TooltipContent>
+                            <p>Add List</p>
+                        </TooltipContent>
+                    </Tooltip>
                 </div>
             </div>
 

--- a/src/components/layout/sidebar/SidebarLists.tsx
+++ b/src/components/layout/sidebar/SidebarLists.tsx
@@ -245,9 +245,16 @@ function SidebarListsInner({ lists: ssrLists, userId }: SidebarListsProps) {
                     </Tooltip>
                     <ManageListDialog
                         trigger={
-                            <Button variant="ghost" size="icon" className="h-7 w-7" title="Add List" aria-label="Add List" data-testid="add-list-button">
-                                <Plus className="h-4 w-4" />
-                            </Button>
+                            <Tooltip>
+                                <TooltipTrigger asChild>
+                                    <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="Add List" data-testid="add-list-button">
+                                        <Plus className="h-4 w-4" />
+                                    </Button>
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                    <p>Add List</p>
+                                </TooltipContent>
+                            </Tooltip>
                         }
                         userId={userId}
                     />


### PR DESCRIPTION
### 💡 What
Added a custom UI `<Tooltip>` to the "Add List" icon-only action button in the `SidebarLists` component, replacing the native HTML `title` attribute.

### 🎯 Why
Native browser `title` attributes are notoriously slow to appear, visually inconsistent across different operating systems and browsers, and can be inaccessible to keyboard users. This change ensures a faster, styled, and consistent tooltip experience when users hover over the "Add List" button, improving the micro-UX.

### 📸 Before/After
Before: The button used `title="Add List"`, relying on the slow browser default tooltip.
After: The button uses the custom Shadcn UI `<Tooltip>` component for immediate feedback.

### ♿ Accessibility
The `aria-label="Add List"` attribute is strictly maintained on the `Button` element to ensure screen readers continue to properly announce the button's action. The use of `<TooltipTrigger asChild>` ensures valid nested HTML.

---
*PR created automatically by Jules for task [17204847148475000706](https://jules.google.com/task/17204847148475000706) started by @lassestilvang*