### PR TITLE
⚡ Bolt: Optimize object emptiness checks

### DIFF
--- a/src/components/layout/sidebar/SidebarLists.tsx
+++ b/src/components/layout/sidebar/SidebarLists.tsx
@@ -4,7 +4,7 @@
 import React, { useState, memo, useMemo, Suspense } from "react";
 import Link from "next/link";
 import { usePathname, useSearchParams as useNextSearchParams } from "next/navigation";
-import { cn } from "@/lib/utils";
+import { cn, isObjectEmpty, isObjectNotEmpty } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Plus, GripVertical, ArrowUpDown } from "lucide-react";
 import { ManageListDialog } from "@/components/tasks/ManageListDialog";
@@ -152,7 +152,8 @@ function SidebarListsInner({ lists: ssrLists, userId }: SidebarListsProps) {
 
     // Derive sorted items directly from store or fallback to props (fixes derived state anti-pattern)
     const { items, itemIds } = useMemo(() => {
-        const source = Object.keys(storeLists).length > 0 ? Object.values(storeLists) : ssrLists;
+        // ⚡ Bolt Opt: Replaced Object.keys(storeLists).length > 0 with O(1) allocation-free check
+        const source = isObjectNotEmpty(storeLists) ? Object.values(storeLists) : ssrLists;
         const sortedItems = [...source].sort((a, b) => (a.position ?? 0) - (b.position ?? 0));
 
         // ⚡ Bolt Opt: Precompute itemIds in a single pass to prevent O(N) array allocation
@@ -168,7 +169,8 @@ function SidebarListsInner({ lists: ssrLists, userId }: SidebarListsProps) {
     // Initialize store once on mount if empty (without creating derived state loops)
     const initializedRef = React.useRef(false);
     React.useEffect(() => {
-        if (!initializedRef.current && ssrLists.length > 0 && Object.keys(storeLists).length === 0) {
+        // ⚡ Bolt Opt: Replaced Object.keys(storeLists).length === 0 with O(1) allocation-free check
+        if (!initializedRef.current && ssrLists.length > 0 && isObjectEmpty(storeLists)) {
             setStoreLists(ssrLists);
             initializedRef.current = true;
         }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,18 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function isObjectEmpty(obj: any): boolean {
+  for (const _ in obj) {
+    return false;
+  }
+  return true;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function isObjectNotEmpty(obj: any): boolean {
+  for (const _ in obj) {
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
⚡ Bolt Opt: Replaced `Object.keys(storeLists).length === 0` (and `> 0`) with `isObjectEmpty` and `isObjectNotEmpty` helper functions. `Object.keys(obj)` forces the creation of an intermediate O(N) array just to check the length, which causes unnecessary memory allocation overhead in frequently run `useEffect`s and `useMemo`s. Using a `for...in` loop instead achieves an O(1) allocation-free check.

---
*PR created automatically by Jules for task [5056868199347351710](https://jules.google.com/task/5056868199347351710) started by @lassestilvang*