### PR TITLE
🎨 Palette: Add tooltips to sidebar icon buttons

### DIFF
--- a/src/components/layout/sidebar/SidebarLabels.tsx
+++ b/src/components/layout/sidebar/SidebarLabels.tsx
@@ -218,14 +218,21 @@ export function SidebarLabels({ labels: ssrLabels, userId }: SidebarLabelsProps)
                             <p>{isReordering ? "Done reordering" : "Reorder labels"}</p>
                         </TooltipContent>
                     </Tooltip>
-                    <ManageLabelDialog
-                        trigger={
-                            <Button variant="ghost" size="icon" className="h-7 w-7" title="Add Label" aria-label="Add Label" data-testid="add-label-button">
-                                <Plus className="h-4 w-4" />
-                            </Button>
-                        }
-                        userId={userId}
-                    />
+                    <Tooltip>
+                        <ManageLabelDialog
+                            trigger={
+                                <TooltipTrigger asChild>
+                                    <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="Add Label" data-testid="add-label-button">
+                                        <Plus className="h-4 w-4" />
+                                    </Button>
+                                </TooltipTrigger>
+                            }
+                            userId={userId}
+                        />
+                        <TooltipContent>
+                            <p>Add Label</p>
+                        </TooltipContent>
+                    </Tooltip>
                 </div>
             </div>
 

--- a/src/components/layout/sidebar/SidebarSavedViews.tsx
+++ b/src/components/layout/sidebar/SidebarSavedViews.tsx
@@ -22,13 +22,22 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 function AddViewHelpDialog({ children }: { children?: React.ReactNode }) {
     return (
         <Dialog>
-            <DialogTrigger asChild>
-                {children || (
-                    <Button variant="ghost" size="icon" className="h-7 w-7" title="How to add a view" aria-label="How to add a view">
-                        <Plus className="h-4 w-4" />
-                    </Button>
-                )}
-            </DialogTrigger>
+            {children ? (
+                <DialogTrigger asChild>{children}</DialogTrigger>
+            ) : (
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <DialogTrigger asChild>
+                            <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="How to add a view">
+                                <Plus className="h-4 w-4" />
+                            </Button>
+                        </DialogTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                        <p>How to add a view</p>
+                    </TooltipContent>
+                </Tooltip>
+            )}
             <DialogContent>
                 <DialogHeader>
                     <DialogTitle>How to create a Saved View</DialogTitle>


### PR DESCRIPTION
💡 **What**: Added `Tooltip` components wrapping the icon-only "Add Label" button in `SidebarLabels.tsx` and the "How to add a view" button in `SidebarSavedViews.tsx`.
🎯 **Why**: These icon-only buttons previously relied on native `title` or `aria-label` attributes, which do not provide immediate, styled visual feedback for sighted users. The tooltips make their purpose obvious on hover.
♿ **Accessibility**: Replaces delayed native tooltips with consistent, styled application tooltips, maintaining keyboard navigation and screen reader support while significantly improving the experience for sighted mouse users.

---
*PR created automatically by Jules for task [2889984279012236911](https://jules.google.com/task/2889984279012236911) started by @lassestilvang*