### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing rate limiting on task completion toggle

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -29,3 +29,8 @@
 **Vulnerability:** The `deleteList` Server Action (`deleteListImpl`) lacked rate limiting.
 **Learning:** Even destructive operations that are presumed to be low frequency (like deleting a user-created list) require consistent rate limiting to protect against programmatic abuse or DoS vectors, similar to other mutative endpoints.
 **Prevention:** Apply the `rateLimit` utility to all destructive Server Actions to maintain a consistent defense-in-depth posture across the application API.
+
+## 2024-05-18 - Missing Rate Limiting on State Mutation Endpoint
+**Vulnerability:** The `toggleTaskCompletionImpl` server action, unlike other task mutations (`createTask`, `updateTask`, `deleteTask`), did not have rate limiting applied.
+**Learning:** Security controls like rate limiting must be consistently applied across all state-mutating endpoints, even seemingly innocuous ones like toggling a boolean. An attacker could rapidly toggle task completion states to trigger numerous downstream side effects (gamification XP recalculations, unblocking dependencies, sync dispatch events, logging), potentially causing DoS.
+**Prevention:** When adding new mutative endpoints or refactoring existing ones, ensure the `rateLimit` utility (or similar controls) is applied uniformly to prevent abuse of downstream side-effects.

--- a/src/lib/actions/tasks/mutations.ts
+++ b/src/lib/actions/tasks/mutations.ts
@@ -497,6 +497,11 @@ export const deleteTask: (
 async function toggleTaskCompletionImpl(id: number, userId: string, isCompleted: boolean) {
   const user = await requireUser(userId);
 
+  const limit = await rateLimit(`task:toggle:${userId}`, 200, 3600);
+  if (!limit.success) {
+    throw new Error("Rate limit exceeded. Please try again later.");
+  }
+
   if (!isValidId(id)) {
     throw new NotFoundError("Task not found or access denied");
   }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Missing rate limiting on a state mutation endpoint. The `toggleTaskCompletionImpl` server action lacked the standard `rateLimit` protection applied to other task mutations.
🎯 **Impact:** An attacker could rapidly hit the endpoint to toggle task completion states. While toggling a boolean is fast, this action triggers a cascade of downstream effects, including gamification XP calculations, unblocking dependency checks, activity logging, and external service sync dispatches. Rapid successive requests could exhaust server resources and cause a Denial of Service (DoS).
🔧 **Fix:** Added `rateLimit(\`task:toggle:${userId}\`, 200, 3600)` to `toggleTaskCompletionImpl` to enforce the same limits present on other task updates.
✅ **Verification:** Ran `bun lint` and `bun test` to ensure tests passed and verified that the `rateLimit` utility is properly imported in `src/lib/actions/tasks/mutations.ts`.

---
*PR created automatically by Jules for task [14468785267602159313](https://jules.google.com/task/14468785267602159313) started by @lassestilvang*