### PR TITLE
🎨 Palette: Explicit type="button" for custom icon picker buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -26,3 +26,6 @@
 ## 2024-06-13 - [Use Custom Tooltips over Native title for Icon-only buttons]
 **Learning:** Using the native HTML `title` attribute for tooltips on icon-only action buttons results in an inconsistent visual experience, delayed appearance, and potential accessibility issues for keyboard users.
 **Action:** Replace native `title` attributes on icon-only buttons with the application's design system `<Tooltip>` component (wrapping `<TooltipTrigger asChild>`) to ensure immediate, visually consistent, and accessible feedback while maintaining the `aria-label` attribute on the button itself.
+## 2024-05-14 - Explicit `type="button"` for custom buttons
+**Learning:** Found multiple instances where custom UI buttons (specifically in the `icon-picker` tabs) were missing the explicit `type="button"` attribute. In HTML, the default type for `<button>` is `"submit"`. If these components are ever reused or nested inside a `<form>` element, clicking them will inadvertently submit the form and cause a disruptive page reload.
+**Action:** Always explicitly set `type="button"` on custom action buttons that are not intended to submit forms.

--- a/src/components/ui/icon-picker/IconsTab.tsx
+++ b/src/components/ui/icon-picker/IconsTab.tsx
@@ -22,6 +22,7 @@ export function IconPickerIconsTab({ state, dispatch, filteredStandardIcons, han
                     {COMMON_COLORS.map(c => (
                         <button
                             key={c}
+                            type="button"
                             onClick={() => dispatch({ type: 'SET_SELECTED_COLOR', payload: selectedColor === c ? null : c })}
                             className={cn(
                                 "w-5 h-5 rounded-full border border-transparent transition-transform hover:scale-110 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-none",
@@ -34,6 +35,7 @@ export function IconPickerIconsTab({ state, dispatch, filteredStandardIcons, han
                         />
                     ))}
                     <button
+                        type="button"
                         onClick={() => dispatch({ type: 'SET_SELECTED_COLOR', payload: null })}
                         className={cn(
                             "w-5 h-5 rounded-full border border-muted bg-transparent flex items-center justify-center text-[10px] focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-none",
@@ -52,6 +54,7 @@ export function IconPickerIconsTab({ state, dispatch, filteredStandardIcons, han
                         {filteredStandardIcons.map((item) => (
                             <button
                                 key={item.name}
+                                type="button"
                                 onClick={() => handleSelectIcon(item.name)}
                                 className="flex items-center justify-center w-full aspect-square rounded-md hover:bg-accent hover:text-accent-foreground transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-none"
                                 title={item.name}

--- a/src/components/ui/icon-picker/LibraryTab.tsx
+++ b/src/components/ui/icon-picker/LibraryTab.tsx
@@ -40,6 +40,7 @@ export function IconPickerLibraryTab({
               {recentIcons.map((r: string) => (
                 <button
                   key={r}
+                  type="button"
                   onClick={() => handleSelectIcon(r)}
                   aria-label={'Select recently used icon ' + r}
                   className="shrink-0 flex items-center justify-center w-8 h-8 rounded-md border border-transparent hover:bg-accent/50 hover:border-border transition-all snap-start bg-secondary/30"
@@ -71,6 +72,7 @@ export function IconPickerLibraryTab({
                 {customIcons.map((c: any) => (
                   <div key={c.id} className="relative group">
                     <button
+                      type="button"
                       onClick={() => handleSelectIcon(c.value)}
                       aria-label={`Select custom icon ${c.name}`}
                       className="flex items-center justify-center w-full aspect-square rounded-md hover:bg-accent/50 transition-colors"
@@ -89,6 +91,7 @@ export function IconPickerLibraryTab({
                     </button>
                     {userId && c.id && (
                       <button
+                        type="button"
                         onClick={async (e) => {
                           e.stopPropagation();
                           if (confirm("Delete this icon?")) {

--- a/src/components/ui/icon-picker/UploadTab.tsx
+++ b/src/components/ui/icon-picker/UploadTab.tsx
@@ -76,6 +76,7 @@ export function IconPickerUploadTab({ state, dispatch, fileInputRef, handlePaste
                                 unoptimized
                             />
                             <button
+                                type="button"
                                 onClick={(e) => { e.stopPropagation(); dispatch({ type: 'SET_UPLOAD_URL', payload: "" }); }}
                                 className="absolute -top-2 -right-2 bg-destructive text-white rounded-full p-1 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 focus-visible:ring-offset-2"
                                 aria-label="Remove uploaded image"


### PR DESCRIPTION
💡 What: Added explicit `type="button"` attributes to several `<button>` elements within the custom `icon-picker` component tabs (`IconsTab`, `LibraryTab`, `UploadTab`).

🎯 Why: In HTML, the default type for a `<button>` element is `"submit"`. If these custom icon picker components are ever nested within a standard `<form>`, clicking any of these utility buttons (e.g., changing colors, selecting an icon, or closing the preview) would inadvertently trigger a full form submission and page reload. Explicitly setting `type="button"` prevents this disruptive behavior and ensures the components are robust and reusable in any context.

📸 Before/After: Visuals remain unchanged.

♿ Accessibility/UX: Improves the robustness and predictability of interactive elements, ensuring they do not trigger unintended side effects when used within complex forms.

---
*PR created automatically by Jules for task [11979584725032186500](https://jules.google.com/task/11979584725032186500) started by @lassestilvang*