### PR TITLE
⚡ Bolt: Optimize array allocation for nonOverdueTasks in useTaskListView

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -22,3 +22,6 @@
 ## 2025-06-17 - Optimize Object Emptiness Check in useMemo
 **Learning:** Relying on `Object.keys(obj).length === 0` to check for object emptiness inside frequently rendered hooks (like `useMemo` or `useEffect`) needlessly allocates an intermediate O(N) array on every evaluation. `Object.values(obj).length > 0` suffers the same issue.
 **Action:** Replace these checks with a fast, allocation-free `for...in` loop that breaks immediately after the first key (e.g., extracted as an `isObjectEmpty(obj)` utility) to reduce memory allocations and garbage collection overhead during renders.
+## 2025-06-25 - [React Reference Preservation in useMemo]
+**Learning:** When conditionally appending items to an array inside a `useMemo` block (e.g., `[...activeTasks, ...(showCompleted ? completedTasks : [])]`), unconditionally returning a newly allocated array or combination (even if the second array is empty) breaks referential equality for the primary array. This can cause unnecessary downstream re-renders.
+**Action:** Use an early return to pass back the original array reference (`if (!showCompleted || completedTasks.length === 0) return activeTasks;`) when no items need to be appended. For the combination, `array.concat()` or a spread operator is sufficient as long as the default state preserves the reference.

--- a/src/hooks/use-task-list-view.ts
+++ b/src/hooks/use-task-list-view.ts
@@ -181,8 +181,11 @@ export function useTaskListView({
     const nonOverdueTasks = useMemo(() => {
         // ⚡ Bolt Opt: Avoid array allocation and reference changes when not showing completed tasks
         // by returning the activeTasks reference directly.
-        if (!settings.showCompleted || completedTasks.length === 0) {
+if (!settings.showCompleted || completedTasks.length === 0) {
             return activeTasks;
+        }
+        if (activeTasks.length === 0) {
+            return completedTasks;
         }
 
         return activeTasks.concat(completedTasks);

--- a/src/hooks/use-task-list-view.ts
+++ b/src/hooks/use-task-list-view.ts
@@ -179,7 +179,13 @@ export function useTaskListView({
     }, [processedTasks, filterType, settings.layout, weekStartsOnMonday, settings.showCompleted]);
 
     const nonOverdueTasks = useMemo(() => {
-        return [...activeTasks, ...(settings.showCompleted ? completedTasks : [])];
+        // ⚡ Bolt Opt: Avoid array allocation and reference changes when not showing completed tasks
+        // by returning the activeTasks reference directly.
+        if (!settings.showCompleted || completedTasks.length === 0) {
+            return activeTasks;
+        }
+
+        return activeTasks.concat(completedTasks);
     }, [activeTasks, completedTasks, settings.showCompleted]);
 
     const groupedEntries = useMemo(() => {


### PR DESCRIPTION
💡 **What**: Refactored the `nonOverdueTasks` `useMemo` block in `use-task-list-view.ts` to implement an early return that preserves the `activeTasks` array reference when completed tasks are not shown (which is the default state). For combining the arrays, we now use `activeTasks.concat(completedTasks)` instead of a spread operator array literal.

🎯 **Why**: The previous implementation `[...activeTasks, ...(settings.showCompleted ? completedTasks : [])]` unconditionally allocated a new array and broke referential equality on every render, even when no completed tasks were added. This degraded memoization and caused unnecessary downstream re-renders in the view components.

📊 **Impact**: 
- Completely eliminates array allocation and prevents reference changes for the default application state (`settings.showCompleted` = false). 
- Reduces downstream component re-renders that rely on the `nonOverdueTasks` reference.

🔬 **Measurement**: Verify by running tests to ensure list task filtering remains correct (`bun test`) and inspecting React DevTools profiler to confirm that list view item components do not re-render as often during state changes that do not affect the task list.

---
*PR created automatically by Jules for task [6717668394958543084](https://jules.google.com/task/6717668394958543084) started by @lassestilvang*