### PR TITLE
🎨 Palette: Explicitly set type="button" on SlimSidebar toggles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -29,3 +29,7 @@
 ## 2024-05-14 - Explicit `type="button"` for custom buttons
 **Learning:** Found multiple instances where custom UI buttons (specifically in the `icon-picker` tabs) were missing the explicit `type="button"` attribute. In HTML, the default type for `<button>` is `"submit"`. If these components are ever reused or nested inside a `<form>` element, clicking them will inadvertently submit the form and cause a disruptive page reload.
 **Action:** Always explicitly set `type="button"` on custom action buttons that are not intended to submit forms.
+
+## 2024-06-07 - Always set type="button" on sidebar toggle buttons
+**Learning:** Custom toggle buttons inside layout components (like `SlimSidebar`) used to expand or hide sidebars often lack the `type="button"` attribute. Since the default HTML behavior is `type="submit"`, this can cause unintended form submissions if the component is nested near a form context.
+**Action:** Always explicitly specify `type="button"` on all custom UI action buttons, including layout toggles and expansible triggers, to ensure safe and predictable interactions.

--- a/src/components/layout/SlimSidebar.tsx
+++ b/src/components/layout/SlimSidebar.tsx
@@ -83,6 +83,7 @@ export function SlimSidebar({
           <Tooltip>
             <TooltipTrigger asChild>
               <button
+                type="button"
                 onClick={onExpand}
                 className="flex items-center justify-center h-8 w-8 rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent transition-all duration-200 outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
                 aria-label="Expand sidebar"
@@ -192,6 +193,7 @@ export function SlimSidebar({
               <Tooltip>
                 <TooltipTrigger asChild>
                   <button
+                    type="button"
                     onClick={onExpand}
                     aria-label={`Show ${lists.length - 5} more lists`}
                     className="flex items-center justify-center h-7 w-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors text-[10px] font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
@@ -258,6 +260,7 @@ export function SlimSidebar({
               <Tooltip>
                 <TooltipTrigger asChild>
                   <button
+                    type="button"
                     onClick={onExpand}
                     aria-label={`Show ${labels.length - 5} more labels`}
                     className="flex items-center justify-center h-7 w-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors text-[10px] font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
@@ -279,6 +282,7 @@ export function SlimSidebar({
         <Tooltip>
           <TooltipTrigger asChild>
             <button
+              type="button"
               onClick={onHide}
               className="flex items-center justify-center h-8 w-8 rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent transition-all duration-200 outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
               aria-label="Hide sidebar"


### PR DESCRIPTION
💡 What: Added `type="button"` attribute to four custom action buttons in the `SlimSidebar` component used for expanding, hiding, and showing additional lists/labels.
🎯 Why: In HTML, the default type for a `<button>` is `"submit"`. When custom UI buttons lack this attribute and are rendered near or inside a `<form>`, clicking them can inadvertently trigger form submissions or full-page reloads. Explicitly defining them as `type="button"` guarantees safe, predictable UI interactions.
📸 Before/After: N/A (Functional/Robustness change, no visual difference).
♿ Accessibility: Ensures robust interactions for screen readers and keyboard users without causing disruptive page reloads.

---
*PR created automatically by Jules for task [14654048963692707817](https://jules.google.com/task/14654048963692707817) started by @lassestilvang*