### PR TITLE
🎨 Palette: Add type='button' to Sidebar action buttons

### DIFF
--- a/src/components/layout/SidebarWrapper.tsx
+++ b/src/components/layout/SidebarWrapper.tsx
@@ -133,6 +133,7 @@ export function SidebarWrapper({ children, className, lists, labels }: SidebarWr
                     <Tooltip>
                         <TooltipTrigger asChild>
                             <button
+                                type="button"
                                 onClick={() => setMode("slim")}
                                 className="flex items-center justify-center h-6 w-6 rounded-md text-foreground/70 hover:text-foreground hover:bg-accent transition-colors"
                                 aria-label="Slim sidebar"
@@ -145,6 +146,7 @@ export function SidebarWrapper({ children, className, lists, labels }: SidebarWr
                     <Tooltip>
                         <TooltipTrigger asChild>
                             <button
+                                type="button"
                                 onClick={() => setMode("hidden")}
                                 className="flex items-center justify-center h-6 w-6 rounded-md text-foreground/70 hover:text-foreground hover:bg-accent transition-colors"
                                 aria-label="Hide sidebar"
@@ -198,6 +200,7 @@ export function SidebarWrapper({ children, className, lists, labels }: SidebarWr
                 <Tooltip>
                     <TooltipTrigger asChild>
                         <button
+                            type="button"
                             onClick={() => setMode("normal")}
                             className="fixed top-3 left-3 z-40 flex items-center justify-center h-8 w-8 rounded-lg bg-card backdrop-blur-sm border border-border text-foreground/70 hover:text-foreground hover:bg-accent shadow-sm transition-all duration-200 hover:shadow-md hover:scale-105 hidden md:flex"
                             aria-label="Show sidebar"

--- a/src/components/layout/sidebar/SidebarSavedViews.tsx
+++ b/src/components/layout/sidebar/SidebarSavedViews.tsx
@@ -129,6 +129,7 @@ export function SidebarSavedViews({ userId }: { userId?: string }) {
                                 <Tooltip>
                                     <TooltipTrigger asChild>
                                         <button
+                                            type="button"
                                             onClick={() => deleteMutation.mutate(view.id)}
                                             className="absolute right-2 top-1/2 -translate-y-1/2 p-1.5 text-muted-foreground hover:text-destructive opacity-0 group-hover:opacity-100 transition-opacity focus:opacity-100 outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
                                             title={`Delete view ${view.name}`}


### PR DESCRIPTION
💡 **What:** Added the explicit `type="button"` attribute to several icon-only action buttons located within the application's sidebar (specifically in `SidebarSavedViews.tsx` and `SidebarWrapper.tsx`).
🎯 **Why:** In HTML, `<button>` elements default to `type="submit"` if the `type` attribute is omitted. While these specific buttons might not currently be nested within a `<form>`, adding `type="button"` is a strict web development and React best practice. It proactively prevents frustrating UX bugs—such as accidental page reloads or unexpected form submissions—if the layout structure is ever modified to include a form context.
♿ **Accessibility:** Enhances overall code robustness and ensures buttons act consistently as UI triggers rather than default submit actions.

---
*PR created automatically by Jules for task [17853684510372370330](https://jules.google.com/task/17853684510372370330) started by @lassestilvang*