### PR TITLE
🎨 Palette: [Add aria-labels to Pomodoro Timer buttons]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -33,3 +33,6 @@
 ## 2024-06-07 - Always set type="button" on sidebar toggle buttons
 **Learning:** Custom toggle buttons inside layout components (like `SlimSidebar`) used to expand or hide sidebars often lack the `type="button"` attribute. Since the default HTML behavior is `type="submit"`, this can cause unintended form submissions if the component is nested near a form context.
 **Action:** Always explicitly specify `type="button"` on all custom UI action buttons, including layout toggles and expansible triggers, to ensure safe and predictable interactions.
+## 2024-06-28 - Provide aria-labels for icon-only action buttons
+**Learning:** Icon-only buttons used for distinct actions (like Play, Pause, Reset in the Pomodoro Timer) lack context for screen reader users when aria-labels are missing.
+**Action:** Always provide an explicit `aria-label` on icon-only `<Button>` components, even when they are wrapped in a `<Tooltip>`, to ensure immediate and descriptive accessibility.


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the start/pause and reset `<Button>` elements in the `PomodoroTimer` component.
🎯 Why: To improve accessibility for screen reader users by providing descriptive context for icon-only action buttons.
📸 Before/After: Not a visual change.
♿ Accessibility: Ensures that screen readers announce the functionality of the timer controls.

---
*PR created automatically by Jules for task [2878583758826405818](https://jules.google.com/task/2878583758826405818) started by @lassestilvang*