### PR TITLE
🛡️ Sentinel: [MEDIUM] Add rate limiting to update operations for lists and labels

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -42,3 +42,7 @@
 **Vulnerability:** The Server Actions for updating (`updateTemplateImpl`) and deleting (`deleteTemplateImpl`) templates were exposed without rate limiting.
 **Learning:** Destructive operations and general mutations must be consistently rate-limited, even if they aren't the primary actions an application supports. Overlooking these creates asymmetric DoS vectors.
 **Prevention:** Apply the codebase's standard `rateLimit` utility on EVERY mutative Server Action.
+## 2025-06-29 - Missing Rate Limiting on Label and List Update Actions
+**Vulnerability:** The Server Actions for updating lists (`updateListImpl`) and updating labels (`updateLabelImpl`) lacked rate limiting.
+**Learning:** While creation actions are often the primary focus for rate limiting, endpoints that perform generic update operations are also vectors for DoS attacks or database exhaustion if left unprotected.
+**Prevention:** Apply the `rateLimit` utility consistently across all mutative Server Actions, not just primary creation entities like tasks or lists.

--- a/src/lib/actions/labels.ts
+++ b/src/lib/actions/labels.ts
@@ -208,6 +208,11 @@ async function updateLabelImpl(
 ) {
   const user = await requireUser(userId);
 
+  const limit = await rateLimit(`label:update:${userId}`, 50, 3600);
+  if (!limit.success) {
+    throw new ValidationError("Rate limit exceeded. Please try again later.");
+  }
+
   if (data.name !== undefined) {
     if (data.name.trim().length === 0) {
       throw new ValidationError("Label name cannot be empty", { name: "Name cannot be empty" });

--- a/src/lib/actions/lists.ts
+++ b/src/lib/actions/lists.ts
@@ -239,6 +239,11 @@ async function updateListImpl(
 ) {
   const user = await requireUser(userId);
 
+  const limit = await rateLimit(`list:update:${userId}`, 50, 3600);
+  if (!limit.success) {
+    throw new ValidationError("Rate limit exceeded. Please try again later.");
+  }
+
   if (data.name !== undefined) {
     if (data.name.trim().length === 0) {
       throw new ValidationError("List name cannot be empty", { name: "Name cannot be empty" });


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing rate limiting on `updateListImpl` and `updateLabelImpl` server actions.
🎯 Impact: Attackers could potentially exhaust database resources or cause a Denial of Service (DoS) by rapidly and repeatedly updating lists or labels.
🔧 Fix: Added the `rateLimit` utility to both update actions with a limit of 50 requests per hour.
✅ Verification: Ran `bun test` successfully and verified that the `rateLimit` utility is properly imported and invoked in both `src/lib/actions/lists.ts` and `src/lib/actions/labels.ts`.

---
*PR created automatically by Jules for task [5413037236081594838](https://jules.google.com/task/5413037236081594838) started by @lassestilvang*