### PR TITLE
🎨 Palette: Add Tooltips to FocusMode buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-06-07 - Always set type="button" on sidebar toggle buttons
 **Learning:** Custom toggle buttons inside layout components (like `SlimSidebar`) used to expand or hide sidebars often lack the `type="button"` attribute. Since the default HTML behavior is `type="submit"`, this can cause unintended form submissions if the component is nested near a form context.
 **Action:** Always explicitly specify `type="button"` on all custom UI action buttons, including layout toggles and expansible triggers, to ensure safe and predictable interactions.
+
+## 2024-07-02 - [Tooltips and Type for FocusMode Buttons]
+**Learning:** Found several icon-only action buttons in the `FocusMode` overlay (minimize, reset, start/pause, complete) that lacked proper Tooltip wrappers and explicitly defined `type="button"` attributes. This degrades accessibility for screen reader and keyboard users and leaves the buttons susceptible to unintentional form submissions if the component tree evolves.
+**Action:** Always wrap custom icon-only action buttons inside complex overlays like `FocusMode` with the standard `<Tooltip>` component and ensure they have `type="button"` specified to provide necessary context and interaction safety.

--- a/src/components/tasks/FocusMode.tsx
+++ b/src/components/tasks/FocusMode.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import { updateTask } from "@/lib/actions";
 import { toast } from "sonner";
 import confetti from "canvas-confetti";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface FocusModeProps {
     task: {
@@ -92,18 +93,26 @@ export function FocusMode({ task, userId, onClose }: FocusModeProps) {
         <div
             className="fixed inset-0 z-[100] bg-background/95 backdrop-blur-sm flex flex-col items-center justify-center p-4 animate-in fade-in duration-300"
         >
-            <Button
-                variant="ghost"
-                size="icon"
-                className="absolute top-4 right-4"
-                onClick={(e) => {
-                    e.stopPropagation();
-                    onClose();
-                }}
-                aria-label="Minimize Focus Mode"
-            >
-                <Minimize2 className="h-6 w-6" />
-            </Button>
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="absolute top-4 right-4"
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            onClose();
+                        }}
+                        aria-label="Minimize Focus Mode"
+                    >
+                        <Minimize2 className="h-6 w-6" />
+                    </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                    <p>Minimize Focus Mode</p>
+                </TooltipContent>
+            </Tooltip>
 
             <div className="max-w-2xl w-full text-center space-y-12">
                 <div className="space-y-4">
@@ -128,41 +137,65 @@ export function FocusMode({ task, userId, onClose }: FocusModeProps) {
                 </div>
 
                 <div className="flex items-center justify-center gap-6">
-                    <Button
-                        size="lg"
-                        variant="outline"
-                        className="h-16 w-16 rounded-full border-2"
-                        onClick={resetTimer}
-                        aria-label="Reset Timer"
-                    >
-                        <RotateCcw className="h-6 w-6" />
-                    </Button>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <Button
+                                type="button"
+                                size="lg"
+                                variant="outline"
+                                className="h-16 w-16 rounded-full border-2"
+                                onClick={resetTimer}
+                                aria-label="Reset Timer"
+                            >
+                                <RotateCcw className="h-6 w-6" />
+                            </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                            <p>Reset Timer</p>
+                        </TooltipContent>
+                    </Tooltip>
 
-                    <Button
-                        size="lg"
-                        className={cn(
-                            "h-24 w-24 rounded-full shadow-lg transition-all hover:scale-105",
-                            isActive ? "bg-red-500 hover:bg-red-600" : "bg-primary hover:bg-primary/90"
-                        )}
-                        onClick={toggleTimer}
-                        aria-label={isActive ? "Pause Timer" : "Start Timer"}
-                    >
-                        {isActive ? (
-                            <Pause className="h-10 w-10" />
-                        ) : (
-                            <Play className="h-10 w-10 ml-1" />
-                        )}
-                    </Button>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <Button
+                                type="button"
+                                size="lg"
+                                className={cn(
+                                    "h-24 w-24 rounded-full shadow-lg transition-all hover:scale-105",
+                                    isActive ? "bg-red-500 hover:bg-red-600" : "bg-primary hover:bg-primary/90"
+                                )}
+                                onClick={toggleTimer}
+                                aria-label={isActive ? "Pause Timer" : "Start Timer"}
+                            >
+                                {isActive ? (
+                                    <Pause className="h-10 w-10" />
+                                ) : (
+                                    <Play className="h-10 w-10 ml-1" />
+                                )}
+                            </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                            <p>{isActive ? "Pause Timer" : "Start Timer"}</p>
+                        </TooltipContent>
+                    </Tooltip>
 
-                    <Button
-                        size="lg"
-                        variant="outline"
-                        className="h-16 w-16 rounded-full border-2 hover:bg-green-100 hover:text-green-700 hover:border-green-200 dark:hover:bg-green-900/30 dark:hover:text-green-400 dark:hover:border-green-800"
-                        onClick={handleComplete}
-                        aria-label="Complete Task"
-                    >
-                        <CheckCircle2 className="h-6 w-6" />
-                    </Button>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <Button
+                                type="button"
+                                size="lg"
+                                variant="outline"
+                                className="h-16 w-16 rounded-full border-2 hover:bg-green-100 hover:text-green-700 hover:border-green-200 dark:hover:bg-green-900/30 dark:hover:text-green-400 dark:hover:border-green-800"
+                                onClick={handleComplete}
+                                aria-label="Complete Task"
+                            >
+                                <CheckCircle2 className="h-6 w-6" />
+                            </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                            <p>Complete Task</p>
+                        </TooltipContent>
+                    </Tooltip>
                 </div>
 
                 <div className="text-sm text-muted-foreground">


### PR DESCRIPTION
💡 **What:** Added descriptive tooltips to the four icon-only action buttons (Minimize, Reset Timer, Start/Pause Timer, Complete Task) in the `FocusMode` overlay, and explicitly set `type="button"` on them.
🎯 **Why:** Icon-only buttons without tooltips lack context for sighted keyboard/mouse users. Defining `type="button"` prevents unintended form submissions if the component tree context ever changes.
♿ **Accessibility:** Improves discoverability of icon actions and provides safe interactive primitives.

---
*PR created automatically by Jules for task [8980446249969625715](https://jules.google.com/task/8980446249969625715) started by @lassestilvang*