### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing rate limit on label and list mutations

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -42,3 +42,12 @@
 **Vulnerability:** The Server Actions for updating (`updateTemplateImpl`) and deleting (`deleteTemplateImpl`) templates were exposed without rate limiting.
 **Learning:** Destructive operations and general mutations must be consistently rate-limited, even if they aren't the primary actions an application supports. Overlooking these creates asymmetric DoS vectors.
 **Prevention:** Apply the codebase's standard `rateLimit` utility on EVERY mutative Server Action.
+
+## 2026-07-04 - [Defense-in-Depth] Enforce Authorization in Internal Helpers
+**Vulnerability:** Internal helper functions (like `logActivity`) that perform database mutations often accept a `userId` parameter but lack an internal `requireUser(userId)` check, assuming the caller has already validated authorization.
+**Learning:** If these internal helpers are ever accidentally exported from a `"use server"` file or directly exposed to an API route, they become vulnerable to Insecure Direct Object Reference (IDOR), allowing an attacker to mutate data for other users by spoofing the `userId`.
+**Prevention:** Apply a defense-in-depth approach by enforcing `requireUser(userId)` or equivalent authorization checks directly within internal mutation helpers, even if they are currently only called by other authenticated Server Actions. Always update the corresponding test suites to mock the authenticated session context when adding these internal checks.
+## 2026-07-06 - [Rate Limiting Missing on Label Update and Delete Endpoints]
+**Vulnerability:** The Server Actions for updating (`updateLabelImpl`) and deleting (`deleteLabelImpl`) labels, and updating (`updateListImpl`) lists were exposed without rate limiting.
+**Learning:** Destructive operations and general mutations must be consistently rate-limited, even if they aren't the primary actions an application supports. Overlooking these creates asymmetric DoS vectors.
+**Prevention:** Apply the codebase's standard rateLimit utility on EVERY mutative Server Action.

--- a/src/lib/actions/labels.ts
+++ b/src/lib/actions/labels.ts
@@ -208,6 +208,11 @@ async function updateLabelImpl(
 ) {
   const user = await requireUser(userId);
 
+  const limit = await rateLimit(`label:update:${userId}`, 100, 3600);
+  if (!limit.success) {
+    throw new ValidationError("Rate limit exceeded. Please try again later.");
+  }
+
   if (data.name !== undefined) {
     if (data.name.trim().length === 0) {
       throw new ValidationError("Label name cannot be empty", { name: "Name cannot be empty" });
@@ -272,6 +277,11 @@ export const updateLabel: (
  */
 async function deleteLabelImpl(id: number, userId: string) {
   const user = await requireUser(userId);
+
+  const limit = await rateLimit(`label:delete:${userId}`, 50, 3600);
+  if (!limit.success) {
+    throw new ValidationError("Rate limit exceeded. Please try again later.");
+  }
 
   const currentLabel = await getLabel(id, userId);
 

--- a/src/lib/actions/lists.ts
+++ b/src/lib/actions/lists.ts
@@ -239,6 +239,11 @@ async function updateListImpl(
 ) {
   const user = await requireUser(userId);
 
+  const limit = await rateLimit(`list:update:${userId}`, 100, 3600);
+  if (!limit.success) {
+    throw new ValidationError("Rate limit exceeded. Please try again later.");
+  }
+
   if (data.name !== undefined) {
     if (data.name.trim().length === 0) {
       throw new ValidationError("List name cannot be empty", { name: "Name cannot be empty" });


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The Server Actions for updating and deleting labels (`updateLabelImpl`, `deleteLabelImpl`) and updating lists (`updateListImpl`) lacked rate limiting.
🎯 Impact: This creates an asymmetric Denial of Service (DoS) vulnerability. An attacker could rapidly hit these unprotected mutative endpoints to artificially inflate server load, drain database connections, or exceed other backend limits.
🔧 Fix: Implemented the existing `rateLimit` utility on these endpoints to cap request rates safely.
✅ Verification: Ran unit tests for rate limits (`bun test src/lib/actions/labels.rate-limit.test.ts` and `bun test src/lib/actions/lists.rate-limit.test.ts`), and the full test suite (`bun test`).

---
*PR created automatically by Jules for task [11930049260792126624](https://jules.google.com/task/11930049260792126624) started by @lassestilvang*