### PR TITLE
⚡ Bolt: Add React.memo to task board components to prevent re-render cascade

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -25,3 +25,6 @@
 ## 2025-06-25 - [React Reference Preservation in useMemo]
 **Learning:** When conditionally appending items to an array inside a `useMemo` block (e.g., `[...activeTasks, ...(showCompleted ? completedTasks : [])]`), unconditionally returning a newly allocated array or combination (even if the second array is empty) breaks referential equality for the primary array. This can cause unnecessary downstream re-renders.
 **Action:** Use an early return to pass back the original array reference (`if (!showCompleted || completedTasks.length === 0) return activeTasks;`) when no items need to be appended. For the combination, `array.concat()` or a spread operator is sufficient as long as the default state preserves the reference.
+## 2024-07-02 - [React.memo & dnd-kit Rendering]
+**Learning:** When tracking global drag state (e.g., setting an active drag item in a parent component) using libraries like `@dnd-kit`, all child elements will re-render by default on every drag state change, causing expensive O(N) re-render cascades in large lists or boards.
+**Action:** Always wrap repeating draggable items (like cards) and their structural containers (like columns) with `React.memo()` to prevent unnecessary re-renders during drag operations.

--- a/src/components/tasks/board/TaskBoardCard.tsx
+++ b/src/components/tasks/board/TaskBoardCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import React, { memo } from "react";
 import { useDraggable } from "@dnd-kit/core";
 import { cn } from "@/lib/utils";
 import { Task } from "@/lib/types";
@@ -19,7 +20,9 @@ const priorityColors: Record<string, string> = {
   none: "border-l-gray-300",
 };
 
-export function TaskBoardCard({ task, onEdit }: TaskBoardCardProps) {
+// ⚡ Bolt Opt: Wrapped TaskBoardCard in React.memo() to prevent O(N) re-render cascades
+// when the parent TaskBoardView updates the active drag state during dragging.
+export const TaskBoardCard = memo(function TaskBoardCard({ task, onEdit }: TaskBoardCardProps) {
   const { attributes, listeners, setNodeRef, transform, isDragging } =
     useDraggable({
       id: task.id,
@@ -135,4 +138,4 @@ export function TaskBoardCard({ task, onEdit }: TaskBoardCardProps) {
       )}
     </div>
   );
-}
+});

--- a/src/components/tasks/board/TaskBoardColumn.tsx
+++ b/src/components/tasks/board/TaskBoardColumn.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import React, { memo } from "react";
 import { useDroppable } from "@dnd-kit/core";
 import { cn } from "@/lib/utils";
 import { Task } from "@/lib/types";
@@ -21,7 +22,9 @@ const colorMap: Record<string, string> = {
   gray: "bg-gray-400",
 };
 
-export function TaskBoardColumn({ column, tasks, onEdit }: TaskBoardColumnProps) {
+// ⚡ Bolt Opt: Wrapped TaskBoardColumn in React.memo() to prevent O(N) re-render cascades
+// when the parent TaskBoardView updates the active drag state during dragging.
+export const TaskBoardColumn = memo(function TaskBoardColumn({ column, tasks, onEdit }: TaskBoardColumnProps) {
   const { setNodeRef, isOver } = useDroppable({
     id: `column:${column.id}`,
     data: { columnId: column.id },
@@ -61,4 +64,4 @@ export function TaskBoardColumn({ column, tasks, onEdit }: TaskBoardColumnProps)
       </div>
     </div>
   );
-}
+});


### PR DESCRIPTION
💡 **What**: Added `React.memo()` wrappers to the `TaskBoardCard` and `TaskBoardColumn` components.
🎯 **Why**: Using `@dnd-kit` to track active drag state inside a parent view forces O(N) re-render cascades across all structurally identical board columns and task cards on every active drag change. 
📊 **Impact**: Prevents full UI re-renders of unaffected task lists during drag operations. Reduces memory footprint and main-thread blockage when interacting with large kanban boards.
🔬 **Measurement**: Run the Next.js app in a development environment with React DevTools profiler enabled. Dragging a task card should no longer cause adjacent columns and untouched task components to flash green/re-render. Tests pass seamlessly.

---
*PR created automatically by Jules for task [18418691871995577922](https://jules.google.com/task/18418691871995577922) started by @lassestilvang*