### PR TITLE
⚡ Bolt: Memoize Object.values for stable useTaskListView dependency

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,6 @@
 ## 2024-07-02 - [React.memo & dnd-kit Rendering]
 **Learning:** When tracking global drag state (e.g., setting an active drag item in a parent component) using libraries like `@dnd-kit`, all child elements will re-render by default on every drag state change, causing expensive O(N) re-render cascades in large lists or boards.
 **Action:** Always wrap repeating draggable items (like cards) and their structural containers (like columns) with `React.memo()` to prevent unnecessary re-renders during drag operations.
+## 2024-07-18 - [Object.values Allocation in Renders]
+**Learning:** Passing `Object.values(storeObject)` directly into custom hooks or dependency arrays inside a component body creates a new O(N) array on *every single render*. This breaks downstream referential equality checks (like in `useMemo`), causing massive performance degradation—especially when the component contains frequent state updates (like a minute-based `now` timer).
+**Action:** Always memoize `Object.values(storeObject)` with `useMemo(() => Object.values(storeObject), [storeObject])` before passing it to hooks or mapping logic to prevent unnecessary allocations and re-renders.

--- a/src/components/tasks/FocusMode.tsx
+++ b/src/components/tasks/FocusMode.tsx
@@ -5,7 +5,7 @@ import { createPortal } from "react-dom";
 import { Play, Pause, CheckCircle2, RotateCcw, Minimize2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
 import { updateTask } from "@/lib/actions";
 import { toast } from "sonner";
 import confetti from "canvas-confetti";

--- a/src/components/tasks/TaskListWithSettings.tsx
+++ b/src/components/tasks/TaskListWithSettings.tsx
@@ -104,8 +104,12 @@ export function TaskListWithSettings({ tasks, title, listId, labelId, defaultDue
 
     useEffect(() => { initialize(); if (tasks?.length) setTasks(tasks); }, [tasks, setTasks, initialize]);
 
+    // ⚡ Bolt Opt: Memoize Object.values(storeTasksFn) to prevent O(N) array allocation
+    // and subsequent expensive hook re-evaluations on every component render (e.g., when `now` updates).
+    const allStoreTasks = useMemo(() => Object.values(storeTasksFn), [storeTasksFn]);
+
     const { processedTasks, listTasks, periodSections, overdueTasks, activeTasks, completedTasks, groupedEntries, derivedTasks } = useTaskListView({
-        allStoreTasks: Object.values(storeTasksFn), listId, labelId, filterType, tasksFromProps: tasks, weekStartsOnMonday: weekStartsOnMonday ?? undefined, settings
+        allStoreTasks, listId, labelId, filterType, tasksFromProps: tasks, weekStartsOnMonday: weekStartsOnMonday ?? undefined, settings
     });
 
     useEffect(() => {

--- a/src/components/tasks/TemplateManager.tsx
+++ b/src/components/tasks/TemplateManager.tsx
@@ -13,7 +13,7 @@ import {
 import { getTemplates, deleteTemplate, instantiateTemplate } from "@/lib/actions";
 import { Plus, Trash2, FileText, Play, Pencil } from "lucide-react";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { toast } from "sonner";
 import { TemplateFormDialog } from "./TemplateFormDialog";
 


### PR DESCRIPTION
💡 **What:** 
Memoized `Object.values(storeTasksFn)` into a stable `allStoreTasks` array using `useMemo` in `TaskListWithSettings.tsx`.

🎯 **Why:** 
The `TaskListWithSettings` component has a minute-based timer (`now`) that updates state frequently. Previously, `Object.values(storeTasksFn)` was passed directly into `useTaskListView`. Since `Object.values` creates a new array reference every time it is called, the frequent component re-renders were breaking referential equality and triggering expensive downstream `useMemo` re-evaluations inside the custom hook.

📊 **Impact:** 
Eliminates an O(N) intermediate array allocation on every single component render and prevents the massive O(N) downstream `useTaskListView` hook from re-evaluating unnecessarily when the minute timer ticks.

🔬 **Measurement:** 
Verify by placing a `console.log` inside the `derivedTasks` useMemo of `useTaskListView.ts` and observing that it no longer logs every 60 seconds when `now` updates in `TaskListWithSettings.tsx`, but only when the `tasks` state actually changes.

---
*PR created automatically by Jules for task [6291897022330160264](https://jules.google.com/task/6291897022330160264) started by @lassestilvang*