### PR TITLE
🎨 Palette: Replace native title with custom Tooltips

### DIFF
--- a/src/components/layout/sidebar/SidebarSavedViews.tsx
+++ b/src/components/layout/sidebar/SidebarSavedViews.tsx
@@ -131,7 +131,6 @@ export function SidebarSavedViews({ userId }: { userId?: string }) {
                                         <button
                                             onClick={() => deleteMutation.mutate(view.id)}
                                             className="absolute right-2 top-1/2 -translate-y-1/2 p-1.5 text-muted-foreground hover:text-destructive opacity-0 group-hover:opacity-100 transition-opacity focus:opacity-100 outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
-                                            title={`Delete view ${view.name}`}
                                             aria-label={`Delete view ${view.name}`}
                                         >
                                             <Trash2 className="h-3.5 w-3.5" />

--- a/src/components/ui/icon-picker.tsx
+++ b/src/components/ui/icon-picker.tsx
@@ -14,6 +14,7 @@ import {
     TabsList,
     TabsTrigger,
 } from "@/components/ui/tabs";
+import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
 import { Search, Shuffle } from "lucide-react";
 import { AVAILABLE_ICONS } from "@/lib/icons";
 import { ResolvedIcon } from "./resolved-icon";
@@ -159,7 +160,16 @@ export function IconPicker({ value, onChange, userId, trigger }: IconPickerProps
                             <TabsTrigger value="icons" className="text-xs h-7">Icons</TabsTrigger>
                             <TabsTrigger value="upload" className="text-xs h-7">Upload</TabsTrigger>
                         </TabsList>
-                        <Button size="icon" variant="ghost" className="h-7 w-7" onClick={handleShuffle} title="Random Icon" aria-label="Random Icon"><Shuffle className="h-3.5 w-3.5" /></Button>
+                        <TooltipProvider>
+                            <Tooltip>
+                                <TooltipTrigger asChild>
+                                    <Button size="icon" variant="ghost" className="h-7 w-7" onClick={handleShuffle} aria-label="Random Icon"><Shuffle className="h-3.5 w-3.5" /></Button>
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                    <p>Random Icon</p>
+                                </TooltipContent>
+                            </Tooltip>
+                        </TooltipProvider>
                     </div>
 
                     {activeTab === "icons" && (


### PR DESCRIPTION
💡 What: Replaced a native HTML `title` attribute on the "Random Icon" button with a custom accessible `<Tooltip>` component, and removed a redundant `title` attribute from a button that already had a `<Tooltip>`.
🎯 Why: Native HTML `title` attributes provide inconsistent, delayed visual feedback, and are completely inaccessible to keyboard-only users who cannot hover. By using the app's standard `<Tooltip>` component, we ensure that sighted keyboard users get visual feedback, and the UI remains consistent. 
📸 Before/After: Visual tooltips now appear consistently and immediately.
♿ Accessibility: Preserved the `aria-label` for screen reader announcements while ensuring sighted keyboard users also receive context for icon-only buttons via the accessible tooltip pattern.

---
*PR created automatically by Jules for task [14770078952162173391](https://jules.google.com/task/14770078952162173391) started by @lassestilvang*