### PR TITLE
🎨 Palette: Replace native titles on buttons with accessible tooltips

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -48,3 +48,7 @@
 ## 2024-07-10 - Provide tooltips for custom icon-only action buttons in full-screen overlays
 **Learning:** Icon-only action buttons (like those used for timers or full-screen focus modes) lack context when presented without tooltips. The `aria-label` helps screen reader users, but sighted users need immediate visual feedback to understand the button's action, especially in distraction-free interfaces where standard UI context is hidden.
 **Action:** Always wrap custom icon-only `<Button>` components (like Reset, Pause/Play, Minimize) with the application's `<Tooltip>` component (using `<TooltipTrigger asChild>`) to ensure immediate, accessible feedback for all users.
+
+## 2024-07-26 - Double tooltips and missing button types
+**Learning:** Found multiple instances where buttons used native `title` attributes despite already being wrapped in custom `<Tooltip>` components, causing a disruptive double-tooltip experience. Additionally, several custom action buttons lacked `type="button"`.
+**Action:** Always verify that native `title` attributes are removed when introducing custom tooltips to an element, and explicitly set `type="button"` on all standalone UI action buttons to prevent accidental form submissions.

--- a/src/components/layout/sidebar/SidebarSavedViews.tsx
+++ b/src/components/layout/sidebar/SidebarSavedViews.tsx
@@ -129,9 +129,9 @@ export function SidebarSavedViews({ userId }: { userId?: string }) {
                                 <Tooltip>
                                     <TooltipTrigger asChild>
                                         <button
+                                            type="button"
                                             onClick={() => deleteMutation.mutate(view.id)}
                                             className="absolute right-2 top-1/2 -translate-y-1/2 p-1.5 text-muted-foreground hover:text-destructive opacity-0 group-hover:opacity-100 transition-opacity focus:opacity-100 outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
-                                            title={`Delete view ${view.name}`}
                                             aria-label={`Delete view ${view.name}`}
                                         >
                                             <Trash2 className="h-3.5 w-3.5" />

--- a/src/components/ui/icon-picker.tsx
+++ b/src/components/ui/icon-picker.tsx
@@ -14,6 +14,7 @@ import {
     TabsList,
     TabsTrigger,
 } from "@/components/ui/tabs";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { Search, Shuffle } from "lucide-react";
 import { AVAILABLE_ICONS } from "@/lib/icons";
 import { ResolvedIcon } from "./resolved-icon";
@@ -159,7 +160,14 @@ export function IconPicker({ value, onChange, userId, trigger }: IconPickerProps
                             <TabsTrigger value="icons" className="text-xs h-7">Icons</TabsTrigger>
                             <TabsTrigger value="upload" className="text-xs h-7">Upload</TabsTrigger>
                         </TabsList>
-                        <Button size="icon" variant="ghost" className="h-7 w-7" onClick={handleShuffle} title="Random Icon" aria-label="Random Icon"><Shuffle className="h-3.5 w-3.5" /></Button>
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <Button size="icon" variant="ghost" className="h-7 w-7" onClick={handleShuffle} aria-label="Random Icon"><Shuffle className="h-3.5 w-3.5" /></Button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                                <p>Random Icon</p>
+                            </TooltipContent>
+                        </Tooltip>
                     </div>
 
                     {activeTab === "icons" && (


### PR DESCRIPTION
💡 What: 
- Removed redundant native `title` attribute on delete button in `SidebarSavedViews` to prevent "double tooltip" issue since it's wrapped in a custom tooltip.
- Added `type="button"` to the delete button in `SidebarSavedViews` to prevent accidental form submissions.
- Replaced native `title` attribute with accessible `<Tooltip>` component on the Random Icon button in `icon-picker.tsx`.

🎯 Why: 
- Using native HTML `title` attributes on elements already wrapped in custom UI tooltips creates an inconsistent and visually noisy "double tooltip" effect where both the custom tooltip and the browser's native tooltip render simultaneously. 
- Standalone UI action buttons that lack an explicit `type="button"` default to `type="submit"`, which can cause unintended, disruptive full-page form submissions if the component is later nested within a `<form>` element.
- Wrapping the Random Icon button with a custom tooltip provides immediate, visually consistent, and accessible feedback compared to the delayed and less accessible native `title` attribute.

♿ Accessibility:
- Ensures visual consistency for sighted mouse users by preventing overlapping tooltips.
- Provides accessible, custom tooltips for icon-only action buttons.
- Maintains `aria-label` attributes to ensure context is still announced correctly for screen reader users.

---
*PR created automatically by Jules for task [17914047975653931772](https://jules.google.com/task/17914047975653931772) started by @lassestilvang*