### PR TITLE
🎨 Palette: Improve tooltip accessibility

### DIFF
--- a/src/components/layout/sidebar/SidebarSavedViews.tsx
+++ b/src/components/layout/sidebar/SidebarSavedViews.tsx
@@ -131,7 +131,6 @@ export function SidebarSavedViews({ userId }: { userId?: string }) {
                                         <button
                                             onClick={() => deleteMutation.mutate(view.id)}
                                             className="absolute right-2 top-1/2 -translate-y-1/2 p-1.5 text-muted-foreground hover:text-destructive opacity-0 group-hover:opacity-100 transition-opacity focus:opacity-100 outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
-                                            title={`Delete view ${view.name}`}
                                             aria-label={`Delete view ${view.name}`}
                                         >
                                             <Trash2 className="h-3.5 w-3.5" />

--- a/src/components/ui/icon-picker.tsx
+++ b/src/components/ui/icon-picker.tsx
@@ -20,6 +20,7 @@ import { ResolvedIcon } from "./resolved-icon";
 import { getCustomIcons, createCustomIcon } from "@/lib/actions/custom-icons";
 import { toast } from "sonner";
 import { useTheme } from "next-themes";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 // Extracted Parts
 import { RECENT_ICONS_KEY, MAX_RECENTS, readRecentIconsFromStorage } from "./icon-picker/types";
@@ -159,7 +160,14 @@ export function IconPicker({ value, onChange, userId, trigger }: IconPickerProps
                             <TabsTrigger value="icons" className="text-xs h-7">Icons</TabsTrigger>
                             <TabsTrigger value="upload" className="text-xs h-7">Upload</TabsTrigger>
                         </TabsList>
-                        <Button size="icon" variant="ghost" className="h-7 w-7" onClick={handleShuffle} title="Random Icon" aria-label="Random Icon"><Shuffle className="h-3.5 w-3.5" /></Button>
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <Button size="icon" variant="ghost" className="h-7 w-7" onClick={handleShuffle} aria-label="Random Icon"><Shuffle className="h-3.5 w-3.5" /></Button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                                <p>Random Icon</p>
+                            </TooltipContent>
+                        </Tooltip>
                     </div>
 
                     {activeTab === "icons" && (


### PR DESCRIPTION
💡 What: Fixed a double tooltip issue on the "Delete view" button in `SidebarSavedViews` and added a proper Shadcn UI `<Tooltip>` to the "Random Icon" button in the `IconPicker`.
🎯 Why: Native HTML `title` attributes provide inconsistent, delayed visual feedback and are inaccessible to keyboard-only users. Furthermore, having a native `title` on an element that also has a custom UI tooltip causes an annoying "double tooltip" effect where both tooltips appear simultaneously.
📸 Before/After: The random icon button now has a stylized UI tooltip on hover/focus instead of a native OS tooltip. The delete view button no longer shows two overlapping tooltips.
♿ Accessibility: Improved keyboard accessibility and screen reader consistency by leveraging Shadcn/Radix UI tooltips and removing duplicate title attributes, while keeping the `aria-label` intact.

---
*PR created automatically by Jules for task [650900887425595664](https://jules.google.com/task/650900887425595664) started by @lassestilvang*