### PR TITLE
🎨 Palette: [UX improvement] Add Tooltip to Minimize action and Timer role in Focus Mode

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -52,3 +52,7 @@
 ## 2024-07-26 - Double tooltips and missing button types
 **Learning:** Found multiple instances where buttons used native `title` attributes despite already being wrapped in custom `<Tooltip>` components, causing a disruptive double-tooltip experience. Additionally, several custom action buttons lacked `type="button"`.
 **Action:** Always verify that native `title` attributes are removed when introducing custom tooltips to an element, and explicitly set `type="button"` on all standalone UI action buttons to prevent accidental form submissions.
+
+## 2024-07-26 - Add Tooltips to standalone overlay controls and manage aria-live on timers
+**Learning:** Icon-only controls in full-screen distraction-free overlays (like the Minimize button in Focus Mode) lack contextual UI headers. Tooltips provide essential context for sighted users. Additionally, countdown timers (updating every second) need `role="timer"` for semantics, but must use `aria-live="off"` to prevent screen readers from aggressively interrupting the user with every tick. Finally, when using Radix UI `TooltipProvider`, it's safer to wrap the entire portal or page content to avoid context mismatches between tooltips nested at different depths.
+**Action:** Wrap custom icon buttons in standalone modes with `<Tooltip>`. Add `role="timer"` and `aria-live="off"` to rapidly ticking countdown displays.

--- a/src/components/tasks/FocusMode.tsx
+++ b/src/components/tasks/FocusMode.tsx
@@ -90,23 +90,31 @@ export function FocusMode({ task, userId, onClose }: FocusModeProps) {
     if (typeof document === 'undefined') return null;
 
     return createPortal(
-        <div
-            className="fixed inset-0 z-[100] bg-background/95 backdrop-blur-sm flex flex-col items-center justify-center p-4 animate-in fade-in duration-300"
-        >
-            <Button
-                variant="ghost"
-                size="icon"
-                className="absolute top-4 right-4"
-                onClick={(e) => {
-                    e.stopPropagation();
-                    onClose();
-                }}
-                aria-label="Minimize Focus Mode"
+        <TooltipProvider>
+            <div
+                className="fixed inset-0 z-[100] bg-background/95 backdrop-blur-sm flex flex-col items-center justify-center p-4 animate-in fade-in duration-300"
             >
-                <Minimize2 className="h-6 w-6" />
-            </Button>
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <Button
+                            variant="ghost"
+                            size="icon"
+                            className="absolute top-4 right-4"
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                onClose();
+                            }}
+                            aria-label="Minimize Focus Mode"
+                        >
+                            <Minimize2 className="h-6 w-6" />
+                        </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="left">
+                        <p>Minimize</p>
+                    </TooltipContent>
+                </Tooltip>
 
-            <div className="max-w-2xl w-full text-center space-y-12">
+                <div className="max-w-2xl w-full text-center space-y-12">
                 <div className="space-y-4">
                     <div className={cn(
                         "inline-flex items-center justify-center px-4 py-1.5 rounded-full text-sm font-medium",
@@ -124,13 +132,16 @@ export function FocusMode({ task, userId, onClose }: FocusModeProps) {
                     )}
                 </div>
 
-                <div className="tabular-nums text-8xl md:text-9xl font-bold tracking-tighter font-mono">
+                <div
+                    className="tabular-nums text-8xl md:text-9xl font-bold tracking-tighter font-mono"
+                    role="timer"
+                    aria-live="off"
+                >
                     {formatTime(timeLeft)}
                 </div>
 
                 <div className="flex items-center justify-center gap-6">
-                    <TooltipProvider>
-                        <Tooltip>
+                    <Tooltip>
                             <TooltipTrigger asChild>
                                 <Button
                                     size="lg"
@@ -182,18 +193,18 @@ export function FocusMode({ task, userId, onClose }: FocusModeProps) {
                                     <CheckCircle2 className="h-6 w-6" />
                                 </Button>
                             </TooltipTrigger>
-                            <TooltipContent>
-                                <p>Complete Task</p>
-                            </TooltipContent>
-                        </Tooltip>
-                    </TooltipProvider>
+                        <TooltipContent>
+                            <p>Complete Task</p>
+                        </TooltipContent>
+                    </Tooltip>
                 </div>
 
                 <div className="text-sm text-muted-foreground">
                     {isActive ? "Stay focused. You got this!" : "Ready to start?"}
                 </div>
             </div>
-        </div>,
+        </div>
+        </TooltipProvider>,
         document.body
     );
 }


### PR DESCRIPTION
💡 What: Added a custom Tooltip to the "Minimize" icon button in the Focus Mode overlay, expanded the `TooltipProvider` to cover the entire portal, and added `role="timer"` with `aria-live="off"` to the countdown display.
🎯 Why: Icon-only buttons in distraction-free overlays lack standard UI context, so the Tooltip provides immediate clarity for sighted users. The `aria-live="off"` prevents screen readers from aggressively announcing every second of the countdown tick.
📸 Before/After: Sighted users now see a "Minimize" tooltip when hovering over the close icon.
♿ Accessibility: Improved screen reader experience by stopping the countdown spam while maintaining the semantic `timer` role.

---
*PR created automatically by Jules for task [2514291580853819811](https://jules.google.com/task/2514291580853819811) started by @lassestilvang*