### PR TITLE
🎨 Palette: Replace native tooltips with accessible Tooltip component in Icon Picker

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -52,3 +52,7 @@
 ## 2024-07-26 - Double tooltips and missing button types
 **Learning:** Found multiple instances where buttons used native `title` attributes despite already being wrapped in custom `<Tooltip>` components, causing a disruptive double-tooltip experience. Additionally, several custom action buttons lacked `type="button"`.
 **Action:** Always verify that native `title` attributes are removed when introducing custom tooltips to an element, and explicitly set `type="button"` on all standalone UI action buttons to prevent accidental form submissions.
+
+## 2024-07-29 - [Use Custom Tooltips over Native title for Icon Picker]
+**Learning:** Using the native HTML `title` attribute for tooltips in dense, interactive custom UI elements like the Icon Picker results in a sluggish and inconsistent hover experience. The delay before the native tooltip appears makes it difficult for users to quickly scan custom icons and colors, and they are inaccessible to keyboard-only users navigating the grid.
+**Action:** Replace native `title` attributes on interactive grid elements (like color swatches and custom icon buttons) with the application's design system `<Tooltip>` component to ensure immediate, visually consistent, and accessible feedback for all users.

--- a/src/components/ui/icon-picker/IconsTab.tsx
+++ b/src/components/ui/icon-picker/IconsTab.tsx
@@ -1,6 +1,7 @@
 
 import React from "react";
 import { TabsContent } from "@/components/ui/tabs";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ResolvedIcon } from "../resolved-icon";
@@ -20,52 +21,68 @@ export function IconPickerIconsTab({ state, dispatch, filteredStandardIcons, han
             <div className="p-4 space-y-4">
                 <div className="flex flex-wrap gap-2 pb-2 border-b">
                     {COMMON_COLORS.map(c => (
-                        <button
-                            key={c}
-                            type="button"
-                            onClick={() => dispatch({ type: 'SET_SELECTED_COLOR', payload: selectedColor === c ? null : c })}
-                            className={cn(
-                                "w-5 h-5 rounded-full border border-transparent transition-transform hover:scale-110 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-none",
-                                selectedColor === c && "ring-2 ring-primary ring-offset-2 scale-110"
-                            )}
-                            style={{ backgroundColor: c }}
-                            title={c}
-                            aria-label={`Select ${c} color`}
-                            aria-pressed={selectedColor === c ? "true" : "false"}
-                        />
+                        <Tooltip key={c}>
+                            <TooltipTrigger asChild>
+                                <button
+                                    type="button"
+                                    onClick={() => dispatch({ type: 'SET_SELECTED_COLOR', payload: selectedColor === c ? null : c })}
+                                    className={cn(
+                                        "w-5 h-5 rounded-full border border-transparent transition-transform hover:scale-110 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-none",
+                                        selectedColor === c && "ring-2 ring-primary ring-offset-2 scale-110"
+                                    )}
+                                    style={{ backgroundColor: c }}
+                                    aria-label={`Select ${c} color`}
+                                    aria-pressed={selectedColor === c ? "true" : "false"}
+                                />
+                            </TooltipTrigger>
+                            <TooltipContent>
+                                {c}
+                            </TooltipContent>
+                        </Tooltip>
                     ))}
-                    <button
-                        type="button"
-                        onClick={() => dispatch({ type: 'SET_SELECTED_COLOR', payload: null })}
-                        className={cn(
-                            "w-5 h-5 rounded-full border border-muted bg-transparent flex items-center justify-center text-[10px] focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-none",
-                            !selectedColor && "ring-2 ring-primary ring-offset-2"
-                        )}
-                        title="None"
-                        aria-label="Clear color selection"
-                        aria-pressed={!selectedColor ? "true" : "false"}
-                    >
-                        <X className="h-3 w-3" />
-                    </button>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <button
+                                type="button"
+                                onClick={() => dispatch({ type: 'SET_SELECTED_COLOR', payload: null })}
+                                className={cn(
+                                    "w-5 h-5 rounded-full border border-muted bg-transparent flex items-center justify-center text-[10px] focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-none",
+                                    !selectedColor && "ring-2 ring-primary ring-offset-2"
+                                )}
+                                aria-label="Clear color selection"
+                                aria-pressed={!selectedColor ? "true" : "false"}
+                            >
+                                <X className="h-3 w-3" />
+                            </button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                            None
+                        </TooltipContent>
+                    </Tooltip>
                 </div>
 
                 <div className="h-[250px] overflow-y-auto pr-2 scrollbar-thin scrollbar-thumb-muted-foreground/20 scrollbar-track-transparent">
                     <div className="grid grid-cols-7 gap-1 pr-1">
                         {filteredStandardIcons.map((item) => (
-                            <button
-                                key={item.name}
-                                type="button"
-                                onClick={() => handleSelectIcon(item.name)}
-                                className="flex items-center justify-center w-full aspect-square rounded-md hover:bg-accent hover:text-accent-foreground transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-none"
-                                title={item.name}
-                                aria-label={`Select ${item.name} icon`}
-                            >
-                                <ResolvedIcon
-                                    icon={item.name}
-                                    className="h-5 w-5"
-                                    color={selectedColor}
-                                />
-                            </button>
+                            <Tooltip key={item.name}>
+                                <TooltipTrigger asChild>
+                                    <button
+                                        type="button"
+                                        onClick={() => handleSelectIcon(item.name)}
+                                        className="flex items-center justify-center w-full aspect-square rounded-md hover:bg-accent hover:text-accent-foreground transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-none"
+                                        aria-label={`Select ${item.name} icon`}
+                                    >
+                                        <ResolvedIcon
+                                            icon={item.name}
+                                            className="h-5 w-5"
+                                            color={selectedColor}
+                                        />
+                                    </button>
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                    {item.name}
+                                </TooltipContent>
+                            </Tooltip>
                         ))}
                     </div>
                 </div>

--- a/src/components/ui/icon-picker/LibraryTab.tsx
+++ b/src/components/ui/icon-picker/LibraryTab.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { TabsContent } from "@/components/ui/tabs";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Loader2, X } from "lucide-react";
 import { ResolvedIcon } from "../resolved-icon";
 import Image from "next/image";
@@ -71,39 +72,52 @@ export function IconPickerLibraryTab({
                 {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
                 {customIcons.map((c: any) => (
                   <div key={c.id} className="relative group">
-                    <button
-                      type="button"
-                      onClick={() => handleSelectIcon(c.value)}
-                      aria-label={`Select custom icon ${c.name}`}
-                      className="flex items-center justify-center w-full aspect-square rounded-md hover:bg-accent/50 transition-colors"
-                      title={c.name}
-                    >
-                      <div className="w-5 h-5 rounded overflow-hidden">
-                        <Image
-                          src={c.value}
-                          alt={c.name}
-                          width={20}
-                          height={20}
-                          className="w-full h-full object-cover"
-                          unoptimized
-                        />
-                      </div>
-                    </button>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          onClick={() => handleSelectIcon(c.value)}
+                          aria-label={`Select custom icon ${c.name}`}
+                          className="flex items-center justify-center w-full aspect-square rounded-md hover:bg-accent/50 transition-colors"
+                        >
+                          <div className="w-5 h-5 rounded overflow-hidden">
+                            <Image
+                              src={c.value}
+                              alt={c.name}
+                              width={20}
+                              height={20}
+                              className="w-full h-full object-cover"
+                              unoptimized
+                            />
+                          </div>
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {c.name}
+                      </TooltipContent>
+                    </Tooltip>
                     {userId && c.id && (
-                      <button
-                        type="button"
-                        onClick={async (e) => {
-                          e.stopPropagation();
-                          if (confirm("Delete this icon?")) {
-                            await deleteCustomIcon(c.id!, userId);
-                            loadCustomIcons();
-                          }
-                        }}
-                        aria-label={`Delete custom icon ${c.name}`}
-                        className="absolute -top-1 -right-1 bg-destructive text-destructive-foreground rounded-full p-0.5 opacity-0 group-hover:opacity-100 focus:opacity-100 focus-visible:opacity-100 transition-opacity z-20"
-                      >
-                        <X className="h-2 w-2" />
-                      </button>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            onClick={async (e) => {
+                              e.stopPropagation();
+                              if (confirm("Delete this icon?")) {
+                                await deleteCustomIcon(c.id!, userId);
+                                loadCustomIcons();
+                              }
+                            }}
+                            aria-label={`Delete custom icon ${c.name}`}
+                            className="absolute -top-1 -right-1 bg-destructive text-destructive-foreground rounded-full p-0.5 opacity-0 group-hover:opacity-100 focus:opacity-100 focus-visible:opacity-100 transition-opacity z-20"
+                          >
+                            <X className="h-2 w-2" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          Delete {c.name}
+                        </TooltipContent>
+                      </Tooltip>
                     )}
                   </div>
                 ))}


### PR DESCRIPTION
💡 What: Replaced native HTML `title` attributes on interactive elements within the Icon Picker (color swatches, icon buttons) with the application's accessible `<Tooltip>` component.
🎯 Why: Native tooltips have a significant delay before appearing, creating a sluggish hover experience in dense UI grids like the icon picker. Users trying to quickly scan colors or icons were frustrated by the delayed and inconsistent feedback.
📸 Before/After: Replaced standard OS tooltips with custom Radix UI tooltips.
♿ Accessibility: Sighted users benefit from immediate, consistent visual feedback without delay, while keyboard users now see the same context since Radix tooltips support keyboard focus triggers which native titles on generic buttons sometimes handle inconsistently. The original `aria-label`s were retained for screen reader users.

---
*PR created automatically by Jules for task [15530718858179380959](https://jules.google.com/task/15530718858179380959) started by @lassestilvang*