### PR TITLE
🎨 Palette: Improve tooltip UX for Icon Picker buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -52,3 +52,6 @@
 ## 2024-07-26 - Double tooltips and missing button types
 **Learning:** Found multiple instances where buttons used native `title` attributes despite already being wrapped in custom `<Tooltip>` components, causing a disruptive double-tooltip experience. Additionally, several custom action buttons lacked `type="button"`.
 **Action:** Always verify that native `title` attributes are removed when introducing custom tooltips to an element, and explicitly set `type="button"` on all standalone UI action buttons to prevent accidental form submissions.
+## 2024-08-01 - Replace native title attributes with custom Tooltip components in IconPicker
+**Learning:** Native `title` attributes on interactive elements like color and icon selection buttons in custom Pickers provide slow, inconsistent visual feedback that harms the user experience compared to custom accessible tooltips provided by the design system.
+**Action:** Replace native `title` attributes on icon and color selection buttons with the application's `<Tooltip>` component to ensure immediate, visually consistent, and accessible feedback while maintaining standard accessibility tags.

--- a/src/components/ui/icon-picker/IconsTab.tsx
+++ b/src/components/ui/icon-picker/IconsTab.tsx
@@ -4,6 +4,7 @@ import { TabsContent } from "@/components/ui/tabs";
 import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ResolvedIcon } from "../resolved-icon";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { COMMON_COLORS, IconPickerState, IconPickerAction } from "./types";
 
 interface IconPickerIconsTabProps {
@@ -20,52 +21,68 @@ export function IconPickerIconsTab({ state, dispatch, filteredStandardIcons, han
             <div className="p-4 space-y-4">
                 <div className="flex flex-wrap gap-2 pb-2 border-b">
                     {COMMON_COLORS.map(c => (
-                        <button
-                            key={c}
-                            type="button"
-                            onClick={() => dispatch({ type: 'SET_SELECTED_COLOR', payload: selectedColor === c ? null : c })}
-                            className={cn(
-                                "w-5 h-5 rounded-full border border-transparent transition-transform hover:scale-110 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-none",
-                                selectedColor === c && "ring-2 ring-primary ring-offset-2 scale-110"
-                            )}
-                            style={{ backgroundColor: c }}
-                            title={c}
-                            aria-label={`Select ${c} color`}
-                            aria-pressed={selectedColor === c ? "true" : "false"}
-                        />
+                        <Tooltip key={c}>
+                            <TooltipTrigger asChild>
+                                <button
+                                    type="button"
+                                    onClick={() => dispatch({ type: 'SET_SELECTED_COLOR', payload: selectedColor === c ? null : c })}
+                                    className={cn(
+                                        "w-5 h-5 rounded-full border border-transparent transition-transform hover:scale-110 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-none",
+                                        selectedColor === c && "ring-2 ring-primary ring-offset-2 scale-110"
+                                    )}
+                                    style={{ backgroundColor: c }}
+                                    aria-label={`Select ${c} color`}
+                                    aria-pressed={selectedColor === c ? "true" : "false"}
+                                />
+                            </TooltipTrigger>
+                            <TooltipContent>
+                                {c}
+                            </TooltipContent>
+                        </Tooltip>
                     ))}
-                    <button
-                        type="button"
-                        onClick={() => dispatch({ type: 'SET_SELECTED_COLOR', payload: null })}
-                        className={cn(
-                            "w-5 h-5 rounded-full border border-muted bg-transparent flex items-center justify-center text-[10px] focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-none",
-                            !selectedColor && "ring-2 ring-primary ring-offset-2"
-                        )}
-                        title="None"
-                        aria-label="Clear color selection"
-                        aria-pressed={!selectedColor ? "true" : "false"}
-                    >
-                        <X className="h-3 w-3" />
-                    </button>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <button
+                                type="button"
+                                onClick={() => dispatch({ type: 'SET_SELECTED_COLOR', payload: null })}
+                                className={cn(
+                                    "w-5 h-5 rounded-full border border-muted bg-transparent flex items-center justify-center text-[10px] focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-none",
+                                    !selectedColor && "ring-2 ring-primary ring-offset-2"
+                                )}
+                                aria-label="Clear color selection"
+                                aria-pressed={!selectedColor ? "true" : "false"}
+                            >
+                                <X className="h-3 w-3" />
+                            </button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                            None
+                        </TooltipContent>
+                    </Tooltip>
                 </div>
 
                 <div className="h-[250px] overflow-y-auto pr-2 scrollbar-thin scrollbar-thumb-muted-foreground/20 scrollbar-track-transparent">
                     <div className="grid grid-cols-7 gap-1 pr-1">
                         {filteredStandardIcons.map((item) => (
-                            <button
-                                key={item.name}
-                                type="button"
-                                onClick={() => handleSelectIcon(item.name)}
-                                className="flex items-center justify-center w-full aspect-square rounded-md hover:bg-accent hover:text-accent-foreground transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-none"
-                                title={item.name}
-                                aria-label={`Select ${item.name} icon`}
-                            >
-                                <ResolvedIcon
-                                    icon={item.name}
-                                    className="h-5 w-5"
-                                    color={selectedColor}
-                                />
-                            </button>
+                            <Tooltip key={item.name}>
+                                <TooltipTrigger asChild>
+                                    <button
+                                        type="button"
+                                        onClick={() => handleSelectIcon(item.name)}
+                                        className="flex items-center justify-center w-full aspect-square rounded-md hover:bg-accent hover:text-accent-foreground transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-none"
+                                        aria-label={`Select ${item.name} icon`}
+                                    >
+                                        <ResolvedIcon
+                                            icon={item.name}
+                                            className="h-5 w-5"
+                                            color={selectedColor}
+                                        />
+                                    </button>
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                    {item.name}
+                                </TooltipContent>
+                            </Tooltip>
                         ))}
                     </div>
                 </div>

--- a/src/components/ui/icon-picker/LibraryTab.tsx
+++ b/src/components/ui/icon-picker/LibraryTab.tsx
@@ -4,6 +4,7 @@ import { Loader2, X } from "lucide-react";
 import { ResolvedIcon } from "../resolved-icon";
 import Image from "next/image";
 import dynamic from "next/dynamic";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { deleteCustomIcon } from "@/lib/actions/custom-icons";
 import { IconPickerState } from "./types";
 
@@ -71,24 +72,30 @@ export function IconPickerLibraryTab({
                 {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
                 {customIcons.map((c: any) => (
                   <div key={c.id} className="relative group">
-                    <button
-                      type="button"
-                      onClick={() => handleSelectIcon(c.value)}
-                      aria-label={`Select custom icon ${c.name}`}
-                      className="flex items-center justify-center w-full aspect-square rounded-md hover:bg-accent/50 transition-colors"
-                      title={c.name}
-                    >
-                      <div className="w-5 h-5 rounded overflow-hidden">
-                        <Image
-                          src={c.value}
-                          alt={c.name}
-                          width={20}
-                          height={20}
-                          className="w-full h-full object-cover"
-                          unoptimized
-                        />
-                      </div>
-                    </button>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          onClick={() => handleSelectIcon(c.value)}
+                          aria-label={`Select custom icon ${c.name}`}
+                          className="flex items-center justify-center w-full aspect-square rounded-md hover:bg-accent/50 transition-colors"
+                        >
+                          <div className="w-5 h-5 rounded overflow-hidden">
+                            <Image
+                              src={c.value}
+                              alt={c.name}
+                              width={20}
+                              height={20}
+                              className="w-full h-full object-cover"
+                              unoptimized
+                            />
+                          </div>
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {c.name}
+                      </TooltipContent>
+                    </Tooltip>
                     {userId && c.id && (
                       <button
                         type="button"


### PR DESCRIPTION
💡 What: Replaced native `title` attributes on color and icon selection buttons in the `IconPicker` component (`IconsTab` and `LibraryTab`) with the design system's custom `<Tooltip>` components.
🎯 Why: Native HTML tooltips appear inconsistently and slowly across different OS and browser combinations. Switching to the custom tooltips provides immediate, visually consistent, and readable feedback, significantly improving the interaction experience for users picking colors or icons.
📸 Before/After: Screenshots captured showing immediate tooltip rendering on hover.
♿ Accessibility: Preserved existing `aria-label`s on the buttons while adding visible tooltips through standard `TooltipTrigger` components to ensure a great experience for both screen reader and sighted users.

---
*PR created automatically by Jules for task [4709810918321361008](https://jules.google.com/task/4709810918321361008) started by @lassestilvang*