### PR TITLE
🎨 Palette: Improve tooltips on Icon Picker buttons

### DIFF
--- a/src/components/ui/icon-picker/IconsTab.tsx
+++ b/src/components/ui/icon-picker/IconsTab.tsx
@@ -5,6 +5,7 @@ import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ResolvedIcon } from "../resolved-icon";
 import { COMMON_COLORS, IconPickerState, IconPickerAction } from "./types";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 
 interface IconPickerIconsTabProps {
     state: IconPickerState;
@@ -20,52 +21,68 @@ export function IconPickerIconsTab({ state, dispatch, filteredStandardIcons, han
             <div className="p-4 space-y-4">
                 <div className="flex flex-wrap gap-2 pb-2 border-b">
                     {COMMON_COLORS.map(c => (
-                        <button
-                            key={c}
-                            type="button"
-                            onClick={() => dispatch({ type: 'SET_SELECTED_COLOR', payload: selectedColor === c ? null : c })}
-                            className={cn(
-                                "w-5 h-5 rounded-full border border-transparent transition-transform hover:scale-110 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-none",
-                                selectedColor === c && "ring-2 ring-primary ring-offset-2 scale-110"
-                            )}
-                            style={{ backgroundColor: c }}
-                            title={c}
-                            aria-label={`Select ${c} color`}
-                            aria-pressed={selectedColor === c ? "true" : "false"}
-                        />
+                        <Tooltip key={c}>
+                            <TooltipTrigger asChild>
+                                <button
+                                    type="button"
+                                    onClick={() => dispatch({ type: 'SET_SELECTED_COLOR', payload: selectedColor === c ? null : c })}
+                                    className={cn(
+                                        "w-5 h-5 rounded-full border border-transparent transition-transform hover:scale-110 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-none",
+                                        selectedColor === c && "ring-2 ring-primary ring-offset-2 scale-110"
+                                    )}
+                                    style={{ backgroundColor: c }}
+                                    aria-label={`Select ${c} color`}
+                                    aria-pressed={selectedColor === c ? "true" : "false"}
+                                />
+                            </TooltipTrigger>
+                            <TooltipContent>
+                                <p>{c}</p>
+                            </TooltipContent>
+                        </Tooltip>
                     ))}
-                    <button
-                        type="button"
-                        onClick={() => dispatch({ type: 'SET_SELECTED_COLOR', payload: null })}
-                        className={cn(
-                            "w-5 h-5 rounded-full border border-muted bg-transparent flex items-center justify-center text-[10px] focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-none",
-                            !selectedColor && "ring-2 ring-primary ring-offset-2"
-                        )}
-                        title="None"
-                        aria-label="Clear color selection"
-                        aria-pressed={!selectedColor ? "true" : "false"}
-                    >
-                        <X className="h-3 w-3" />
-                    </button>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <button
+                                type="button"
+                                onClick={() => dispatch({ type: 'SET_SELECTED_COLOR', payload: null })}
+                                className={cn(
+                                    "w-5 h-5 rounded-full border border-muted bg-transparent flex items-center justify-center text-[10px] focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-none",
+                                    !selectedColor && "ring-2 ring-primary ring-offset-2"
+                                )}
+                                aria-label="Clear color selection"
+                                aria-pressed={!selectedColor ? "true" : "false"}
+                            >
+                                <X className="h-3 w-3" />
+                            </button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                            <p>None</p>
+                        </TooltipContent>
+                    </Tooltip>
                 </div>
 
                 <div className="h-[250px] overflow-y-auto pr-2 scrollbar-thin scrollbar-thumb-muted-foreground/20 scrollbar-track-transparent">
                     <div className="grid grid-cols-7 gap-1 pr-1">
                         {filteredStandardIcons.map((item) => (
-                            <button
-                                key={item.name}
-                                type="button"
-                                onClick={() => handleSelectIcon(item.name)}
-                                className="flex items-center justify-center w-full aspect-square rounded-md hover:bg-accent hover:text-accent-foreground transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-none"
-                                title={item.name}
-                                aria-label={`Select ${item.name} icon`}
-                            >
-                                <ResolvedIcon
-                                    icon={item.name}
-                                    className="h-5 w-5"
-                                    color={selectedColor}
-                                />
-                            </button>
+                            <Tooltip key={item.name}>
+                                <TooltipTrigger asChild>
+                                    <button
+                                        type="button"
+                                        onClick={() => handleSelectIcon(item.name)}
+                                        className="flex items-center justify-center w-full aspect-square rounded-md hover:bg-accent hover:text-accent-foreground transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-none"
+                                        aria-label={`Select ${item.name} icon`}
+                                    >
+                                        <ResolvedIcon
+                                            icon={item.name}
+                                            className="h-5 w-5"
+                                            color={selectedColor}
+                                        />
+                                    </button>
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                    <p>{item.name}</p>
+                                </TooltipContent>
+                            </Tooltip>
                         ))}
                     </div>
                 </div>

--- a/src/components/ui/icon-picker/LibraryTab.tsx
+++ b/src/components/ui/icon-picker/LibraryTab.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import dynamic from "next/dynamic";
 import { deleteCustomIcon } from "@/lib/actions/custom-icons";
 import { IconPickerState } from "./types";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 
 const EmojiPicker = dynamic(() => import("emoji-picker-react"), { ssr: false });
 
@@ -71,39 +72,52 @@ export function IconPickerLibraryTab({
                 {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
                 {customIcons.map((c: any) => (
                   <div key={c.id} className="relative group">
-                    <button
-                      type="button"
-                      onClick={() => handleSelectIcon(c.value)}
-                      aria-label={`Select custom icon ${c.name}`}
-                      className="flex items-center justify-center w-full aspect-square rounded-md hover:bg-accent/50 transition-colors"
-                      title={c.name}
-                    >
-                      <div className="w-5 h-5 rounded overflow-hidden">
-                        <Image
-                          src={c.value}
-                          alt={c.name}
-                          width={20}
-                          height={20}
-                          className="w-full h-full object-cover"
-                          unoptimized
-                        />
-                      </div>
-                    </button>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          onClick={() => handleSelectIcon(c.value)}
+                          aria-label={`Select custom icon ${c.name}`}
+                          className="flex items-center justify-center w-full aspect-square rounded-md hover:bg-accent/50 transition-colors"
+                        >
+                          <div className="w-5 h-5 rounded overflow-hidden">
+                            <Image
+                              src={c.value}
+                              alt={c.name}
+                              width={20}
+                              height={20}
+                              className="w-full h-full object-cover"
+                              unoptimized
+                            />
+                          </div>
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>{c.name}</p>
+                      </TooltipContent>
+                    </Tooltip>
                     {userId && c.id && (
-                      <button
-                        type="button"
-                        onClick={async (e) => {
-                          e.stopPropagation();
-                          if (confirm("Delete this icon?")) {
-                            await deleteCustomIcon(c.id!, userId);
-                            loadCustomIcons();
-                          }
-                        }}
-                        aria-label={`Delete custom icon ${c.name}`}
-                        className="absolute -top-1 -right-1 bg-destructive text-destructive-foreground rounded-full p-0.5 opacity-0 group-hover:opacity-100 focus:opacity-100 focus-visible:opacity-100 transition-opacity z-20"
-                      >
-                        <X className="h-2 w-2" />
-                      </button>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            onClick={async (e) => {
+                              e.stopPropagation();
+                              if (confirm("Delete this icon?")) {
+                                await deleteCustomIcon(c.id!, userId);
+                                loadCustomIcons();
+                              }
+                            }}
+                            aria-label={`Delete custom icon ${c.name}`}
+                            className="absolute -top-1 -right-1 bg-destructive text-destructive-foreground rounded-full p-0.5 opacity-0 group-hover:opacity-100 focus:opacity-100 focus-visible:opacity-100 transition-opacity z-20"
+                          >
+                            <X className="h-2 w-2" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>Delete icon</p>
+                        </TooltipContent>
+                      </Tooltip>
                     )}
                   </div>
                 ))}

--- a/update_palette_journal.py
+++ b/update_palette_journal.py
@@ -1,4 +1,6 @@
-## 2024-05-30 - Added Explicit Label Associations to Custom Inputs
+import re
+
+content = """## 2024-05-30 - Added Explicit Label Associations to Custom Inputs
 **Learning:** For custom inputs (like Radix UI Select triggers or standard textareas), using a semantic <label> without an htmlFor attribute fails to associate the label with the input. This prevents screen readers from announcing the label when the input receives focus and prevents the browser from transferring focus when the label is clicked.
 **Action:** When building or modifying custom form controls, always generate a unique ID (e.g., using React.useId()) and pass it to the input/trigger, then link the <label> using htmlFor. Adding a cursor-pointer class to the label provides immediate visual feedback that it is interactive.
 
@@ -52,3 +54,6 @@
 ## 2024-07-27 - Remove native title from buttons wrapped in Tooltips
 **Learning:** Applying a native HTML `title` attribute directly on a `<button>` that is wrapped inside a custom `<Tooltip>` and `<TooltipTrigger asChild>` causes redundant tooltips to display simultaneously.
 **Action:** Always remove native `title` attributes when migrating elements to use custom accessible `<Tooltip>` components to avoid a disruptive visual overlap.
+"""
+with open('.jules/palette.md', 'w') as f:
+    f.write(content)


### PR DESCRIPTION
💡 What: Replaced native HTML `title` attributes on the color selection, standard icon, custom icon, and delete buttons inside the Icon Picker (`IconsTab` and `LibraryTab`) with the accessible `Tooltip` component from shadcn/Radix UI.
🎯 Why: Native `title` attributes on buttons provide inconsistent visual experiences, delayed appearances, and are challenging for keyboard-only users. Using the application's consistent custom Tooltips provides immediate visual feedback, better aesthetics, and conforms to the UX standards.
📸 Before/After: Replaced standard OS native tooltips with custom Next.js UI tooltips. Included a screenshot during verification proving the new visual setup.
♿ Accessibility: Custom Tooltips correctly communicate with screen readers through `TooltipContent` while visually presenting without relying solely on the hover-dependent native tooltip.

---
*PR created automatically by Jules for task [3202188299562307353](https://jules.google.com/task/3202188299562307353) started by @lassestilvang*