### PR TITLE
🎨 Palette: [UX improvement] Use custom Tooltips in Icon Picker

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -52,3 +52,7 @@
 ## 2024-07-26 - Double tooltips and missing button types
 **Learning:** Found multiple instances where buttons used native `title` attributes despite already being wrapped in custom `<Tooltip>` components, causing a disruptive double-tooltip experience. Additionally, several custom action buttons lacked `type="button"`.
 **Action:** Always verify that native `title` attributes are removed when introducing custom tooltips to an element, and explicitly set `type="button"` on all standalone UI action buttons to prevent accidental form submissions.
+
+## 2024-07-27 - Remove native title from buttons when wrapping in Tooltips
+**Learning:** Adding a Radix UI `<Tooltip>` component to a button but forgetting to remove its native HTML `title` attribute results in a double-tooltip effect where the browser's default tooltip overlaps the custom styled one.
+**Action:** Always verify that native `title` attributes are completely removed from the DOM node when replacing them with custom accessible `<Tooltip>` components.

--- a/src/components/ui/icon-picker/IconsTab.tsx
+++ b/src/components/ui/icon-picker/IconsTab.tsx
@@ -5,6 +5,7 @@ import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ResolvedIcon } from "../resolved-icon";
 import { COMMON_COLORS, IconPickerState, IconPickerAction } from "./types";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface IconPickerIconsTabProps {
     state: IconPickerState;
@@ -20,52 +21,68 @@ export function IconPickerIconsTab({ state, dispatch, filteredStandardIcons, han
             <div className="p-4 space-y-4">
                 <div className="flex flex-wrap gap-2 pb-2 border-b">
                     {COMMON_COLORS.map(c => (
-                        <button
-                            key={c}
-                            type="button"
-                            onClick={() => dispatch({ type: 'SET_SELECTED_COLOR', payload: selectedColor === c ? null : c })}
-                            className={cn(
-                                "w-5 h-5 rounded-full border border-transparent transition-transform hover:scale-110 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-none",
-                                selectedColor === c && "ring-2 ring-primary ring-offset-2 scale-110"
-                            )}
-                            style={{ backgroundColor: c }}
-                            title={c}
-                            aria-label={`Select ${c} color`}
-                            aria-pressed={selectedColor === c ? "true" : "false"}
-                        />
+                        <Tooltip key={c}>
+                            <TooltipTrigger asChild>
+                                <button
+                                    type="button"
+                                    onClick={() => dispatch({ type: 'SET_SELECTED_COLOR', payload: selectedColor === c ? null : c })}
+                                    className={cn(
+                                        "w-5 h-5 rounded-full border border-transparent transition-transform hover:scale-110 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-none",
+                                        selectedColor === c && "ring-2 ring-primary ring-offset-2 scale-110"
+                                    )}
+                                    style={{ backgroundColor: c }}
+                                    aria-label={`Select ${c} color`}
+                                    aria-pressed={selectedColor === c ? "true" : "false"}
+                                />
+                            </TooltipTrigger>
+                            <TooltipContent>
+                                {c}
+                            </TooltipContent>
+                        </Tooltip>
                     ))}
-                    <button
-                        type="button"
-                        onClick={() => dispatch({ type: 'SET_SELECTED_COLOR', payload: null })}
-                        className={cn(
-                            "w-5 h-5 rounded-full border border-muted bg-transparent flex items-center justify-center text-[10px] focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-none",
-                            !selectedColor && "ring-2 ring-primary ring-offset-2"
-                        )}
-                        title="None"
-                        aria-label="Clear color selection"
-                        aria-pressed={!selectedColor ? "true" : "false"}
-                    >
-                        <X className="h-3 w-3" />
-                    </button>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <button
+                                type="button"
+                                onClick={() => dispatch({ type: 'SET_SELECTED_COLOR', payload: null })}
+                                className={cn(
+                                    "w-5 h-5 rounded-full border border-muted bg-transparent flex items-center justify-center text-[10px] focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-none",
+                                    !selectedColor && "ring-2 ring-primary ring-offset-2"
+                                )}
+                                aria-label="Clear color selection"
+                                aria-pressed={!selectedColor ? "true" : "false"}
+                            >
+                                <X className="h-3 w-3" />
+                            </button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                            None
+                        </TooltipContent>
+                    </Tooltip>
                 </div>
 
                 <div className="h-[250px] overflow-y-auto pr-2 scrollbar-thin scrollbar-thumb-muted-foreground/20 scrollbar-track-transparent">
                     <div className="grid grid-cols-7 gap-1 pr-1">
                         {filteredStandardIcons.map((item) => (
-                            <button
-                                key={item.name}
-                                type="button"
-                                onClick={() => handleSelectIcon(item.name)}
-                                className="flex items-center justify-center w-full aspect-square rounded-md hover:bg-accent hover:text-accent-foreground transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-none"
-                                title={item.name}
-                                aria-label={`Select ${item.name} icon`}
-                            >
-                                <ResolvedIcon
-                                    icon={item.name}
-                                    className="h-5 w-5"
-                                    color={selectedColor}
-                                />
-                            </button>
+                            <Tooltip key={item.name}>
+                                <TooltipTrigger asChild>
+                                    <button
+                                        type="button"
+                                        onClick={() => handleSelectIcon(item.name)}
+                                        className="flex items-center justify-center w-full aspect-square rounded-md hover:bg-accent hover:text-accent-foreground transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-none"
+                                        aria-label={`Select ${item.name} icon`}
+                                    >
+                                        <ResolvedIcon
+                                            icon={item.name}
+                                            className="h-5 w-5"
+                                            color={selectedColor}
+                                        />
+                                    </button>
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                    {item.name}
+                                </TooltipContent>
+                            </Tooltip>
                         ))}
                     </div>
                 </div>

--- a/src/components/ui/icon-picker/LibraryTab.tsx
+++ b/src/components/ui/icon-picker/LibraryTab.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import dynamic from "next/dynamic";
 import { deleteCustomIcon } from "@/lib/actions/custom-icons";
 import { IconPickerState } from "./types";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 const EmojiPicker = dynamic(() => import("emoji-picker-react"), { ssr: false });
 
@@ -71,24 +72,30 @@ export function IconPickerLibraryTab({
                 {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
                 {customIcons.map((c: any) => (
                   <div key={c.id} className="relative group">
-                    <button
-                      type="button"
-                      onClick={() => handleSelectIcon(c.value)}
-                      aria-label={`Select custom icon ${c.name}`}
-                      className="flex items-center justify-center w-full aspect-square rounded-md hover:bg-accent/50 transition-colors"
-                      title={c.name}
-                    >
-                      <div className="w-5 h-5 rounded overflow-hidden">
-                        <Image
-                          src={c.value}
-                          alt={c.name}
-                          width={20}
-                          height={20}
-                          className="w-full h-full object-cover"
-                          unoptimized
-                        />
-                      </div>
-                    </button>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          onClick={() => handleSelectIcon(c.value)}
+                          aria-label={`Select custom icon ${c.name}`}
+                          className="flex items-center justify-center w-full aspect-square rounded-md hover:bg-accent/50 transition-colors"
+                        >
+                          <div className="w-5 h-5 rounded overflow-hidden">
+                            <Image
+                              src={c.value}
+                              alt={c.name}
+                              width={20}
+                              height={20}
+                              className="w-full h-full object-cover"
+                              unoptimized
+                            />
+                          </div>
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {c.name}
+                      </TooltipContent>
+                    </Tooltip>
                     {userId && c.id && (
                       <button
                         type="button"

--- a/update_palette.py
+++ b/update_palette.py
@@ -1,0 +1,12 @@
+import os
+
+journal_path = ".jules/palette.md"
+
+entry = """
+## 2024-07-27 - Remove native title from buttons when wrapping in Tooltips
+**Learning:** Adding a Radix UI `<Tooltip>` component to a button but forgetting to remove its native HTML `title` attribute results in a double-tooltip effect where the browser's default tooltip overlaps the custom styled one.
+**Action:** Always verify that native `title` attributes are completely removed from the DOM node when replacing them with custom accessible `<Tooltip>` components.
+"""
+
+with open(journal_path, "a") as f:
+    f.write(entry)


### PR DESCRIPTION
💡 **What**: Replaced native HTML `title` attributes with custom Radix UI `<Tooltip>` components for color swatches, color clearer, standard icons, and custom icons in the Icon Picker component (`IconsTab.tsx` and `LibraryTab.tsx`).
🎯 **Why**: Using the native HTML `title` attribute for tooltips on icon-only and color-only action buttons results in an inconsistent visual experience, delayed appearance, and potential accessibility issues. Sighted users need immediate and clear visual feedback for these small targets.
📸 **Before/After**: 
*Before*: System-default, delayed tooltips on hover.
*After*: Immediate, themed Radix UI tooltips matching the rest of the application's design system.
♿ **Accessibility**: Enhanced visual accessibility by providing consistent, high-contrast tooltips that follow the established application pattern.

---
*PR created automatically by Jules for task [533111760966168733](https://jules.google.com/task/533111760966168733) started by @lassestilvang*